### PR TITLE
Implement ability to select model/checkpoint to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pydata
 venv
 
 outputs/*.png
+resources/models.csv
 resources/stats.txt
 resources/*.json
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ USER = your username
 PASS = your password
 COPY = set to anything if you want the bot to output the command that was used to produce the image instead of the prompt
 ```
-- On first launch, AIYA will generate a models.csv with a default dummy value. If you'd like to add more models/checkpoints, replace the default value and add lines following the format in the header. An example may look like:
+- On first launch, AIYA will generate a models.csv with a default dummy value. If you'd like to add more models/checkpoints, replace the default value and add lines following the header format.
+  - Display name is anything you want. Full name is how it would appear in the Web UI. An example may look like:
 ```
 display_name|model_full_name
 SD 1.5|v1-5-pruned-emaonly.ckpt [81761151]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To generate an image from text, use the /draw command and include your prompt as
 ### Currently supported options
 
 - negative prompts
+- swap model/checkpoint (_see Notes_)
 - sampling steps
 - height/width (up to 768)
 - CFG scale
@@ -26,6 +27,7 @@ To generate an image from text, use the /draw command and include your prompt as
 
 - /settings command - set per-server defaults for the following (_also see Notes!_):
   - negative prompts
+  - model/checkpoint
   - sampling steps / max steps
   - sampling method
   - batch count / max batch count
@@ -49,7 +51,7 @@ TOKEN = put your bot token here
 
 ## Notes
 
-- Ensure your bot has `bot` and `application.commands` scopes when inviting to your Discord server, and intents are enabled.
+- Ensure AIYA has `bot` and `application.commands` scopes when inviting to your Discord server, and intents are enabled.
 - As /settings can be abused, consider reviewing who can access the command. This can be done through Apps -> Integrations in your Server Settings.
 - React to generated images with ❌ to delete them.
 - Optional .env variables you can set:
@@ -64,3 +66,10 @@ USER = your username
 PASS = your password
 COPY = set to anything if you want the bot to output the command that was used to produce the image instead of the prompt
 ```
+- On first launch, AIYA will generate a models.csv with a default dummy value. If you'd like to add more models/checkpoints, replace the default value and add lines following the format in the header. An example may look like:
+```
+display_name|model_full_name
+SD 1.5|v1-5-pruned-emaonly.ckpt [81761151]
+WD 1.3|wd-v1-3-float32.ckpt [4470c325]
+```
+- In the Web UI, there is a setting named "Checkpoints to cache in RAM". If you have enough RAM, this value can be increased to speed up swapping.

--- a/aiya.py
+++ b/aiya.py
@@ -15,11 +15,11 @@ load_dotenv()
 self.logger = get_logger(__name__)
 
 #load extensions
-self.load_extension('core.settingscog')
 # check files and global variables
-settings.files_check(self)
+settings.files_check()
 settings.old_api_check()
 
+self.load_extension('core.settingscog')
 self.load_extension('core.stablecog')
 self.load_extension('core.tipscog')
 
@@ -35,6 +35,8 @@ async def stats(ctx):
 async def on_ready():
     self.logger.info(f'Logged in as {self.user.name} ({self.user.id})')
     await self.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name='drawing tutorials.'))
+    #because guilds are only known when on_ready, run files check for guilds
+    settings.guilds_check(self)
 
 #feature to delete generations. give bot 'Add Reactions' permission (or not, to hide the ❌)
 @self.event
@@ -64,7 +66,7 @@ async def on_raw_reaction_add(ctx):
 @self.event
 async def on_guild_join(guild):
     print(f'Wow, I joined {guild.name}! Refreshing settings.')
-    settings.files_check(self)
+    settings.guilds_check(self)
 
 async def shutdown(bot):
     await bot.close()

--- a/aiya.py
+++ b/aiya.py
@@ -33,6 +33,7 @@ async def on_ready():
     await self.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name='drawing tutorials.'))
     #check files and global variables
     settings.files_check(self)
+    settings.old_api_check()
 
 #feature to delete generations. give bot 'Add Reactions' permission (or not, to hide the ❌)
 @self.event

--- a/aiya.py
+++ b/aiya.py
@@ -15,8 +15,12 @@ load_dotenv()
 self.logger = get_logger(__name__)
 
 #load extensions
-self.load_extension('core.stablecog')
 self.load_extension('core.settingscog')
+# check files and global variables
+settings.files_check(self)
+settings.old_api_check()
+
+self.load_extension('core.stablecog')
 self.load_extension('core.tipscog')
 
 #stats slash command
@@ -31,9 +35,6 @@ async def stats(ctx):
 async def on_ready():
     self.logger.info(f'Logged in as {self.user.name} ({self.user.id})')
     await self.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name='drawing tutorials.'))
-    #check files and global variables
-    settings.files_check(self)
-    settings.old_api_check()
 
 #feature to delete generations. give bot 'Add Reactions' permission (or not, to hide the ❌)
 @self.event

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import os
 import requests
@@ -58,7 +59,17 @@ def files_check(self):
         pass
     else:
         print(f'Uh oh, stats.txt missing. Creating a new one.')
-        with open('resources/stats.txt', 'w') as f: f.write('0')
+        with open('resources/stats.txt', 'w') as f:
+            f.write('0')
+    if os.path.isfile('resources/models.csv'):
+        pass
+    else:
+        print(f'Uh oh, models.csv missing. Creating a new one.')
+        header = ['model display name', 'model name in web ui']
+        with open('resources/models.csv', 'w', newline='', encoding='utf-8') as f:
+            f.write("#Enter your list of models following the format. Don't remove these first two rows!\n")
+            writer = csv.writer(f, delimiter = "|")
+            writer.writerow(header)
     if os.path.isfile('resources/None.json'):
         pass
     else:

--- a/core/settings.py
+++ b/core/settings.py
@@ -66,9 +66,8 @@ def files_check():
         pass
     else:
         print(f'Uh oh, models.csv missing. Creating a new one.')
-        header = ['model display name', 'model name in web ui']
+        header = ['display_name', 'model_full_name']
         with open('resources/models.csv', 'w', newline='', encoding='utf-8') as f:
-            f.write("#Enter your list of models following the format. Don't remove these first two rows!\n")
             writer = csv.writer(f, delimiter = "|")
             writer.writerow(header)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -107,15 +107,15 @@ def old_api_check():
     config_url = requests.get(global_var.url + "/config")
     old_config = config_url.json()
     global model_fn_index
+    #check all dependencies in config to see if there's a target value
+    #and if there is, match the target value to the id value of component we want
+    #this provides the fn_index needed for the payload to old api
     for d in range(len(old_config["dependencies"])):
-        #check all dependencies in config to see if there's a target value
-        #and if there is, match the target value to the id value of component we want
-        #this provides the fn_index needed for the payload to old api
         try:
             for c in old_config["components"]:
                 if old_config["dependencies"][d]["targets"][0] == c["id"] and c["props"].get(
                         "label") == "Stable Diffusion checkpoint":
-                    model_fn_index = d
+                    global_var.model_fn_index = d
                     print("The fn_index for the model is " + str(model_fn_index) + "!")
         except:
             pass

--- a/core/settings.py
+++ b/core/settings.py
@@ -16,7 +16,8 @@ template = {
             "negative_prompt": "",
             "max_steps": 50,
             "default_count": 1,
-            "max_count": 1
+            "max_count": 1,
+            "data_model": ""
         }
 
 #initialize global variables here

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,5 +1,6 @@
 import json
 import os
+import requests
 from typing import Optional
 import discord
 
@@ -25,6 +26,7 @@ class GlobalVar:
     username: Optional[str] = None
     password: Optional[str] = None
     copy_command: bool = False
+    model_fn_index = 0
 
 global_var = GlobalVar()
 
@@ -88,3 +90,21 @@ def files_check(self):
     if dir_exists is False:
         print(f'The folder for DIR doesn\'t exist! Creating folder at {global_var.dir}.')
         os.mkdir(global_var.dir)
+
+#iterate through the old api at /config to get things we need that don't exist in new api
+def old_api_check():
+    config_url = requests.get(global_var.url + "/config")
+    old_config = config_url.json()
+    global model_fn_index
+    for d in range(len(old_config["dependencies"])):
+        #check all dependencies in config to see if there's a target value
+        #and if there is, match the target value to the id value of component we want
+        #this provides the fn_index needed for the payload to old api
+        try:
+            for c in old_config["components"]:
+                if old_config["dependencies"][d]["targets"][0] == c["id"] and c["props"].get(
+                        "label") == "Stable Diffusion checkpoint":
+                    model_fn_index = d
+                    print("The fn_index for the model is " + str(model_fn_index) + "!")
+        except:
+            pass

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -1,5 +1,7 @@
+import csv
 from discord import option
 from discord.ext import commands
+from discord.commands import OptionChoice
 from typing import Optional
 from core import settings
 
@@ -7,6 +9,9 @@ from core import settings
 class SettingsCog(commands.Cog):
     def __init__(self, bot:commands.Bot):
         self.bot = bot
+
+    with open('resources/models.csv', encoding='utf-8') as csv_file:
+        model_data = list(csv.reader(csv_file, delimiter='|'))
 
     @commands.slash_command(name = 'settings', description = 'Review and change server defaults')
     @option(
@@ -20,6 +25,13 @@ class SettingsCog(commands.Cog):
         str,
         description='Set default negative prompt for the server',
         required=False,
+    )
+    @option(
+        'set_model',
+        str,
+        description='Set default dataset for image generation',
+        required=False,
+        choices=[OptionChoice(name=row[0], value=row[1]) for row in model_data[1:]]
     )
     @option(
         'set_steps',
@@ -59,6 +71,7 @@ class SettingsCog(commands.Cog):
     async def settings_handler(self, ctx,
                                current_settings: Optional[bool] = False,
                                set_nprompt: Optional[str] = 'unset',
+                               set_model: Optional[str] = None,
                                set_steps: Optional[int] = 1,
                                set_maxsteps: Optional[int] = 1,
                                set_count: Optional[int] = None,
@@ -76,6 +89,10 @@ class SettingsCog(commands.Cog):
         if set_nprompt != 'unset':
             settings.update(guild, 'negative_prompt', set_nprompt)
             reply = reply + '\nNew default negative prompts is "' + str(set_nprompt) + '".'
+
+        if set_model is not None:
+            settings.update(guild, 'data_model', set_model)
+            reply = reply + '\nNew default data model is "' + str(set_model) + '".'
 
         if set_sampler != 'unset':
             settings.update(guild, 'sampler', set_sampler)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -66,7 +66,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
     @option(
         'data_model',
         str,
-        description='Select the dataset for image generation',
+        description='Select the data model for image generation',
         required=False,
         choices=[OptionChoice(name=row[0], value=row[1]) for row in model_data[1:]]
     )
@@ -186,7 +186,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             steps = settings.read(guild)['max_steps']
             append_options = append_options + '\nExceeded maximum of ``' + str(steps) + '`` steps! This is the best I can do...'
         if model_name != 'Default':
-            append_options = append_options + '\nDataset: ``' + str(model_name) + '``'
+            append_options = append_options + '\nModel: ``' + str(model_name) + '``'
         if negative_prompt != '':
             append_options = append_options + '\nNegative Prompt: ``' + str(negative_prompt) + '``'
         if height != 512:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -45,9 +45,9 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         self.wait_message = []
         self.bot = bot
         self.post_model = ""
+        self.send_model = False
 
     with open('resources/models.csv', encoding='utf-8') as csv_file:
-        #include a check here if user does not fill out csv
         model_data = list(csv.reader(csv_file, delimiter='|'))
 
     @commands.slash_command(name = 'draw', description = 'Create an image')
@@ -140,12 +140,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             count: Optional[int] = None):
         print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
 
-        #fallback model if not selected
-        if data_model is None:
+        #if a model is not selected, do nothing
+        if data_model is None or data_model == '':
             model_name = "Default"
-            self.post_model = settings.global_var.default_model
         else:
             self.post_model = data_model
+            self.send_model = True
         #get the selected model's display name
         with open('resources/models.csv', 'r', encoding='utf-8') as f:
             reader = csv.DictReader(f, delimiter='|')
@@ -269,8 +269,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 }
                 payload.update(img_payload)
 
-            #send payload to webui, starting with model
-            requests.post(url=f'{settings.global_var.url}/api/predict', json=model_payload)
+            #only send model payload if one is defined
+            if self.send_model:
+                requests.post(url=f'{settings.global_var.url}/api/predict', json=model_payload)
+            #send normal payload to webui
             with requests.Session() as s:
                 if settings.global_var.username is not None:
                     login_payload = {

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -68,7 +68,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         str,
         description='Select the dataset for image generation',
         required=False,
-        choices=[OptionChoice(name=row[0], value=row[1]) for row in model_data[2:]]
+        choices=[OptionChoice(name=row[0], value=row[1]) for row in model_data[1:]]
     )
     @option(
         'steps',
@@ -142,7 +142,16 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
         #fallback model if not selected
         if data_model is None:
+            model_name = "Default"
             self.post_model = settings.global_var.default_model
+        else:
+            self.post_model = data_model
+        #get the selected model's display name
+        with open('resources/models.csv', 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f, delimiter='|')
+            for row in reader:
+                if row['model_full_name'] == data_model:
+                    model_name = row['display_name']
 
         #update defaults with any new defaults from settingscog
         guild = '% s' % ctx.guild_id
@@ -214,10 +223,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 await ctx.send_response(content=f'Please wait! You\'re queued up.', ephemeral=True)
             else:
                 self.queue.append(QueueObject(ctx, prompt, negative_prompt, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count))
-                await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(self.queue)}`` - ``{prompt}``\nDataset: ``{data_model}`` - Steps: ``{steps}`` - Seed: ``{seed}``{append_options}')
+                await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(self.queue)}`` - ``{prompt}``\nDataset: ``{model_name}`` - Steps: ``{steps}`` - Seed: ``{seed}``{append_options}')
         else:
             await self.process_dream(QueueObject(ctx, prompt, negative_prompt, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count))
-            await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(self.queue)}`` - ``{prompt}``\nDataset: ``{data_model}`` - Steps: ``{steps}`` - Seed: ``{seed}``{append_options}')
+            await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(self.queue)}`` - ``{prompt}``\nDataset: ``{model_name}`` - Steps: ``{steps}`` - Seed: ``{seed}``{append_options}')
 
     async def process_dream(self, queue_object: QueueObject):
         self.dream_thread = Thread(target=self.dream,


### PR DESCRIPTION
This will resolve #22

As potential support for this is undetermined through the new API, I am going through the old API.

The envisioned functionality is (may change through testing):
- on launch, aiya will spit out a models.csv file if it doesn't exist (this needs to be added to .gitignore)
- entries in the file will be line by line, delimited by | or something
- bot owner can fill this file with desired models with format `display_name|model_full_name`
an example file can be (the 1st line will be ignored):
```
display_name|model_full_name
SD 1.5|v1-5-pruned-emaonly.ckpt [81761151]
WD 1.3|wd-v1-3-float32.ckpt [4470c325]
```
So on launch, if said file exist and is filled out, aiya will look through the entries and construct a data_model option accordingly. If model doesn't exist (typo in csv or whatever), she should complain and use whichever is the current set model in web ui.
When changing model, it'll have to post to the old API separately first, through `{url}\api\predict`, before sending payload to new API

- if bot owner does not want to fill out models.csv, there will be no data_model option in /draw (is this possible??) and it'll use whatever web ui has set

edit: unfortunately not possible to hide data_model option if models.csv is not filled. I just set a prefilled "Default" option that passes no arguments.
if model doesn't exist, web ui already has a fallback feature. but in terms of communicating what's happening to discord bot end user, it could be improved 🤔