### PR TITLE
Wrong starting point for image_base64 array

### DIFF
--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -320,7 +320,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             # save local copy of image and prepare PIL images
             pil_images = []
             for i, image_base64 in enumerate(response_data['images']):
-                image = Image.open(io.BytesIO(base64.b64decode(image_base64.split(",",1)[1])))
+                image = Image.open(io.BytesIO(base64.b64decode(image_base64.split(",",1)[0])))
                 pil_images.append(image)
 
                 metadata = PngImagePlugin.PngInfo()


### PR DESCRIPTION
Hello, I noticed a small mistake in the stablecog.py file:
`image = Image.open(io.BytesIO(base64.b64decode(image_base64.split(",",1)[1])))`

The starting index should be 0, but it's currently 1 causing a txt2img error with an IndexError: list index out of range.

I don't know if it's linked to the latest update from WebUI (currently running on `172c4bc09f0866e7dd114068ebe0f9abfe79ef33`)