### PR TITLE
Autopopulate "sampler" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A Discord bot interface for Stable Diffusion
 
 <img src=https://raw.githubusercontent.com/Kilvoctu/kilvoctu.github.io/master/pics/preview.png  width=50% height=50%>
 
+## Setup requirements
+
+- Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
+  - AIYA is currently tested on commit `2f47724b73c40b96e158bea9ac2c6e84fbad3e73` of the Web UI.
+- Run the Web UI as local host with api (`COMMANDLINE_ARGS= --listen --api`).
+- Clone this repo.
+- Create a text file in your cloned repo called ".env", formatted like so:
+```dotenv
+# .env
+TOKEN = put your bot token here
+```
+- Run the AIYA by running launch.bat (or launch.sh for Linux)
+
 ## Usage
 
 To generate an image from text, use the /draw command and include your prompt as the query.
@@ -34,21 +47,6 @@ To generate an image from text, use the /draw command and include your prompt as
   - batch count / max batch count
 - /stats command - shows how many /draw commands have been used.
 - /tips command - basic tips for writing prompts.
-
-## Setup requirements
-
-- Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
-  - AIYA is currently tested on commit `321e13ca176b256177c4a752d1f2bbee79b5532e` of the Web UI.
-- Run the Web UI as local host with api (`COMMANDLINE_ARGS= --listen --api`).
-- Clone this repo.
-- Create a text file in your cloned repo called ".env", formatted like so:
-
-```dotenv
-# .env
-TOKEN = put your bot token here
-```
-
-- Run the bot by running launch.bat (or launch.sh for Linux)
 
 ## Notes
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -27,6 +27,7 @@ class GlobalVar:
     embed_color = discord.Colour.from_rgb(222, 89, 28)
     username: Optional[str] = None
     password: Optional[str] = None
+    sampler_names = []
     copy_command: bool = False
     model_fn_index = 0
 
@@ -97,6 +98,22 @@ def files_check():
     if dir_exists is False:
         print(f'The folder for DIR doesn\'t exist! Creating folder at {global_var.dir}.')
         os.mkdir(global_var.dir)
+
+    #pull list of samplers from api
+    with requests.Session() as s:
+        if global_var.username is not None:
+            login_payload = {
+                'username': global_var.username,
+                'password': global_var.password
+            }
+            s.post(global_var.url + '/login', data=login_payload)
+            r = s.get(global_var.url + "/sdapi/v1/samplers")
+        else:
+            s.post(global_var.url + '/login')
+            r = s.get(global_var.url + "/sdapi/v1/samplers")
+        for s in r.json():
+            sampler = s['name']
+            global_var.sampler_names.append(sampler)
 
 def guilds_check(self):
     #guild settings files. has to be done after on_ready

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -66,7 +66,7 @@ class SettingsCog(commands.Cog):
         str,
         description='Set default sampler for the server',
         required=False,
-        choices=['Euler a', 'Euler', 'LMS', 'Heun', 'DPM2', 'DPM2 a', 'DPM fast', 'DPM adaptive', 'LMS Karras', 'DPM2 Karras', 'DPM2 a Karras', 'DDIM', 'PLMS'],
+        choices=settings.global_var.sampler_names,
     )
     async def settings_handler(self, ctx,
                                current_settings: Optional[bool] = False,

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -80,7 +80,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         str,
         description='The sampler to use for generation. Default: Euler a',
         required=False,
-        choices=['Euler a', 'Euler', 'LMS', 'Heun', 'DPM2', 'DPM2 a', 'DPM fast', 'DPM adaptive', 'LMS Karras', 'DPM2 Karras', 'DPM2 a Karras', 'DDIM', 'PLMS'],
+        choices=settings.global_var.sampler_names,
     )
     @option(
         'seed',


### PR DESCRIPTION
This uses the new API endpoints added with A1111 commit `371c4b990eca3f2418e62ce8c852e9a52d39e445` https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/371c4b990eca3f2418e62ce8c852e9a52d39e445

It adds some code in the files_check() function
First it gets a response from /sdapi/v1/samplers
The names we want are acquired, then sent to a global variable
After which, the `sampler` option in /draw and /settings are filled in using that variable

Should work for listen and gradio share