### PR TITLE
Support for styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discord bot interface for Stable Diffusion
 ## Setup requirements
 
 - Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
-  - AIYA is currently tested on commit `2f47724b73c40b96e158bea9ac2c6e84fbad3e73` of the Web UI.
+  - AIYA is currently tested on commit `804d9fb83d0c63ca3acd36378707ce47b8f12599` of the Web UI.
 - Run the Web UI as local host with api (`COMMANDLINE_ARGS= --listen --api`).
 - Clone this repo.
 - Create a text file in your cloned repo called ".env", formatted like so:
@@ -35,6 +35,7 @@ To generate an image from text, use the /draw command and include your prompt as
 - img2img
 - denoising strength
 - batch count
+- Web UI styles
 - face restoration
 
 #### Bonus features

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -5,7 +5,7 @@ from threading import Thread
 #the queue object for txt2image and img2img
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed,
-                 strength, init_image, copy_command, batch_count, facefix):
+                 strength, init_image, copy_command, batch_count, style, facefix):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -20,6 +20,7 @@ class DrawObject:
         self.init_image = init_image
         self.copy_command = copy_command
         self.batch_count = batch_count
+        self.style = style
         self.facefix = facefix
 
 #any command that needs to wait on processing should use the dream thread

--- a/core/settings.py
+++ b/core/settings.py
@@ -28,7 +28,7 @@ class GlobalVar:
     username: Optional[str] = None
     password: Optional[str] = None
     sampler_names = []
-    style_names = []
+    style_names = {}
     copy_command: bool = False
     model_fn_index = 0
 
@@ -114,12 +114,11 @@ def files_check():
             s.post(global_var.url + '/login')
             r = s.get(global_var.url + "/sdapi/v1/samplers")
             r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
-        for s in r.json():
-            sampler = s['name']
+        for s1 in r.json():
+            sampler = s1['name']
             global_var.sampler_names.append(sampler)
-        for s in r2.json():
-            style = s['name']
-            global_var.style_names.append(style)
+        for s2 in r2.json():
+            global_var.style_names[s2['name']] = s2['prompt']
 
 def guilds_check(self):
     #guild settings files. has to be done after on_ready

--- a/core/settings.py
+++ b/core/settings.py
@@ -28,6 +28,7 @@ class GlobalVar:
     username: Optional[str] = None
     password: Optional[str] = None
     sampler_names = []
+    style_names = []
     copy_command: bool = False
     model_fn_index = 0
 
@@ -99,7 +100,7 @@ def files_check():
         print(f'The folder for DIR doesn\'t exist! Creating folder at {global_var.dir}.')
         os.mkdir(global_var.dir)
 
-    #pull list of samplers from api
+    #pull list of samplers and styles from api
     with requests.Session() as s:
         if global_var.username is not None:
             login_payload = {
@@ -108,12 +109,17 @@ def files_check():
             }
             s.post(global_var.url + '/login', data=login_payload)
             r = s.get(global_var.url + "/sdapi/v1/samplers")
+            r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
         else:
             s.post(global_var.url + '/login')
             r = s.get(global_var.url + "/sdapi/v1/samplers")
+            r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
         for s in r.json():
             sampler = s['name']
             global_var.sampler_names.append(sampler)
+        for s in r2.json():
+            style = s['name']
+            global_var.style_names.append(style)
 
 def guilds_check(self):
     #guild settings files. has to be done after on_ready

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -112,6 +112,13 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         required=False,
     )
     @option(
+        'style',
+        str,
+        description='Apply a predefined style to the generation.',
+        required=False,
+        choices=settings.global_var.style_names,
+    )
+    @option(
         'facefix',
         bool,
         description='Tries to improve faces in pictures.',
@@ -129,6 +136,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             init_image: Optional[discord.Attachment] = None,
                             init_url: Optional[str],
                             count: Optional[int] = None,
+                            style: Optional[str] = 'None',
                             facefix: Optional[bool] = False):
 
         #update defaults with any new defaults from settingscog
@@ -213,6 +221,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 count = max_count
                 append_options = append_options + '\nExceeded maximum of ``' + str(count) + '`` images! This is the best I can do...'
             append_options = append_options + '\nCount: ``' + str(count) + '``'
+        if style != 'None':
+            append_options = append_options + '\nStyle: ``' + str(style) + '``'
         if facefix:
             append_options = append_options + '\nFace restoration: ``' + str(facefix) + '``'
 
@@ -224,6 +234,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             copy_command = copy_command + f' data_model:{model_name}'
         if init_image:
             copy_command = copy_command + f' strength:{strength} init_url:{init_image.url}'
+        if style != 'None':
+            copy_command = copy_command + f' style:{style}'
         if facefix:
             copy_command = copy_command + f' facefix:{facefix}'
         print(copy_command)
@@ -238,10 +250,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if user_already_in_queue:
                 await ctx.send_response(content=f'Please wait! You\'re queued up.', ephemeral=True)
             else:
-                queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, facefix))
+                queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix))
                 await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{append_options}')
         else:
-            await queuehandler.process_dream(self, queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, facefix))
+            await queuehandler.process_dream(self, queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix))
             await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{append_options}')
 
     #generate the image
@@ -268,7 +280,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 "seed_resize_from_h": 0,
                 "seed_resize_from_w": 0,
                 "denoising_strength": None,
-                "n_iter": queue_object.batch_count
+                "n_iter": queue_object.batch_count,
+                "styles": [
+                    queue_object.style
+                ]
             }
             if queue_object.init_image is not None:
                 image = base64.b64encode(requests.get(queue_object.init_image.url, stream=True).content).decode('utf-8')

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -20,6 +20,7 @@ from core import settings
 
 
 class StableCog(commands.Cog, name='Stable Diffusion', description='Create images from natural language.'):
+    ctx_parse = discord.ApplicationContext
     def __init__(self, bot):
         self.wait_message = []
         self.bot = bot
@@ -27,6 +28,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
     with open('resources/models.csv', encoding='utf-8') as csv_file:
         model_data = list(csv.reader(csv_file, delimiter='|'))
+
+    #pulls from style_names list and makes some sort of dynamic list to bypass Discord 25 choices limit
+    def style_autocomplete(self: discord.AutocompleteContext):
+        return [
+            style for style in settings.global_var.style_names
+        ]
 
     @commands.slash_command(name = 'draw', description = 'Create an image')
     @option(
@@ -116,7 +123,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         str,
         description='Apply a predefined style to the generation.',
         required=False,
-        choices=settings.global_var.style_names,
+        autocomplete=discord.utils.basic_autocomplete(style_autocomplete),
     )
     @option(
         'facefix',

--- a/core/tipscog.py
+++ b/core/tipscog.py
@@ -1,5 +1,20 @@
 import discord
 from discord.ext import commands
+from discord.ui import View
+
+from core import settings
+
+
+class view(View):
+    @discord.ui.button(label="View the styles list", style=discord.ButtonStyle.primary)
+    async def button_callback(self, button, interaction):
+        button.disabled = True
+        style_list = ''
+        for i, j in settings.global_var.style_names.items():
+            style_list = style_list + str(i) + ' - ``' + str(j) + ' ``\n'
+        embed2 = discord.Embed(title="Style list", description=style_list)
+        await interaction.response.edit_message(view=self)
+        await interaction.followup.send("Here you go!", embed=embed2, ephemeral=True)
 
 class TipsCog(commands.Cog):
     def __init__(self, bot):
@@ -7,6 +22,7 @@ class TipsCog(commands.Cog):
         
     @commands.slash_command(name = "tips", description = "Some quick tips for generating images!")
     async def tips(self, ctx):
+
         embed=discord.Embed(title="Quick Tips", description="")
         embed.add_field(name="Steps", value="This is how many cycles the AI takes to create an image. More steps generally leads to better results, but not always!", inline=False)
         embed.add_field(name="Guidance Scale", value="This represents how much importance is given to your prompt. The AI will give more attention to your prompt with higher values and be more creative with lower values.", inline=False)
@@ -17,7 +33,7 @@ class TipsCog(commands.Cog):
         embed.add_field(name="Alternating", value="`[word1|word2]`\nWhen generating an image, the AI will alternate between the words for each step. Word order still applies.", inline=True)
         embed.set_footer(text='Also, you can react with ❌ to delete your generated images.')
 
-        await ctx.respond(embed=embed, ephemeral=True)
+        await ctx.respond(embed=embed, view=view(), ephemeral=True)
 
 def setup(bot):
     bot.add_cog(TipsCog(bot))


### PR DESCRIPTION
This PR will add support to apply the user-defined styles from the Web UI. This will close #27

The process is reusing a lot of what I did with PR #41

For this PR I will also want to update the /tips command so user knows what styles are available and what tokens they contain.
For that, I want to use buttons: the list of styles will be on another page of /tips

I will need to implement Discord's autocomplete feature: https://docs.pycord.dev/en/stable/api.html#discord.AutocompleteContext
The reason is, normally slash command options have a 25 choice limit. If it goes over, the command will error out.
Autocomplete should solve the scenario in which a user has over 25 styles set up.

While slash commands are simple and user-friendly, there is another limitation. When an option is selected, it can't be selected again. This means only one style can be added at a time. 