### PR TITLE
Option to provide preset model activation token

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,18 @@ DIR = set folder to save images, otherwise the default is \outputs
 
 USER = your username
 PASS = your password
-COPY = set to anything if you want the bot to output the command that was used to produce the image instead of the prompt
+COPY = set to anything to have the output show the command used to produce the image instead of the prompt
 ```
 - On first launch, AIYA will generate a models.csv with a default dummy value. If you'd like to add more models/checkpoints, replace the default value and add lines following the header format.
-  - Display name is anything you want. Full name is how it would appear in the Web UI. An example may look like:
+  - Display name is anything you want.
+  - Model full name is how it would appear in the Web UI.
+  - Activator token is any words a model may need to take effect. Can be blank (remember to add | separator at the end).
+  - An example may look like:
 ```
-display_name|model_full_name
-SD 1.5|v1-5-pruned-emaonly.ckpt [81761151]
-WD 1.3|wd-v1-3-float32.ckpt [4470c325]
+display_name|model_full_name|activator_token
+SD 1.5|v1-5-pruned-emaonly.ckpt [81761151]|
+WD 1.3|wd-v1-3-float32.ckpt [4470c325]|
+MoDi 1|moDi-v1-pruned.ckpt [ccf3615f]|Modern Disney style
 ```
 - In the Web UI, there is a setting named "Checkpoints to cache in RAM". If you have enough RAM, this value can be increased to speed up swapping.
 

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -5,7 +5,7 @@ from threading import Thread
 #the queue object for txt2image and img2img
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed,
-                 strength, init_image, copy_command, batch_count, style, facefix):
+                 strength, init_image, copy_command, batch_count, style, facefix, simple_prompt):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -22,6 +22,7 @@ class DrawObject:
         self.batch_count = batch_count
         self.style = style
         self.facefix = facefix
+        self.simple_prompt = simple_prompt
 
 #any command that needs to wait on processing should use the dream thread
 class GlobalQueue:

--- a/core/settings.py
+++ b/core/settings.py
@@ -65,16 +65,32 @@ def files_check():
         with open('resources/stats.txt', 'w') as f:
             f.write('0')
 
-    header = ['display_name', 'model_full_name']
-    unset_model = ['Default', '']
+    header = ['display_name', 'model_full_name', 'activator_token']
+    unset_model = ['Default', '', '']
     make_model_file = True
-    #if models.csv exists and has data, assume it's good to go
+    replace_model_file = False
+    #if models.csv exists and has data
     if os.path.isfile('resources/models.csv'):
         with open('resources/models.csv', encoding='utf-8') as f:
-            reader = csv.reader(f)
+            reader = csv.reader(f, delimiter="|")
             for i, row in enumerate(reader):
+                #if header is missing columns, reformat the file
+                if i == 0:
+                    if len(row)<3:
+                        with open('resources/models.csv', 'r') as fp:
+                            reader = csv.DictReader(fp, fieldnames=header, delimiter = "|")
+                            with open('resources/models2.csv', 'w', newline='') as fh:
+                                writer = csv.DictWriter(fh, fieldnames=reader.fieldnames, delimiter = "|")
+                                writer.writeheader()
+                                header = next(reader)
+                                writer.writerows(reader)
+                                replace_model_file = True
+                #if first row has data, do nothing
                 if i == 1:
                     make_model_file = False
+        if replace_model_file:
+            os.remove('resources/models.csv')
+            os.rename('resources/models2.csv', 'resources/models.csv')
     #otherwise create/reformat it
     if make_model_file:
         print(f'Uh oh, missing models.csv data. Creating a new one.')

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -2,7 +2,6 @@ import base64
 import contextlib
 import csv
 import io
-import json
 import random
 import time
 import traceback


### PR DESCRIPTION
This PR adds a feature that allows the user to automatically add tokens to the prompt for any model in models.csv

Some models require extra keywords in the prompt in order to benefit from the model's effect. For example, the popular ["mo-di-diffusion"](https://huggingface.co/nitrosocke/mo-di-diffusion) requires the prompt to include "modern disney style".

For people using a lot of models, it can be very tedious to type in the activation keywords every time, or it can be hard to remember what they are.

This PR edits the existing models.csv to include 3 columns, `display_name|model_full_name|activator_token`. This process is automatic.

The user then has the option to include any desired activation keywords. For example:
```
display_name|model_full_name|activator_token
SD 1.5|v1-5-pruned-emaonly.ckpt [81761151]|
WD 1.3|wd-v1-3-float32.ckpt [4470c325]|
MoDi 1|moDi-v1-pruned.ckpt [ccf3615f]|Modern Disney style
```
If aiya sees keywords in the `activator_token` column, she will prepend the prompt with it when user selects the respective model.
Otherwise, nothing special will happen.

Nuances:
Some models I've seen have multiple different activation keywords; user can choose to do x or y style. I don't have a good way to handle these use cases.

I don't like activation keyword to be in the output so it will be hidden. So instead of aiya saying, "I drew `modern disney style pikachu`", it will be  "I drew `pikachu`"