### PR TITLE
Reroll with different seed

### DIFF
--- a/aiya.py
+++ b/aiya.py
@@ -41,16 +41,7 @@ async def on_ready():
     #because guilds are only known when on_ready, run files check for guilds
     settings.guilds_check(self)
 
-#feature to delete generations. give bot 'Add Reactions' permission (or not, to hide the ❌)
-@self.event
-async def on_message(message):
-    if message.author == self.user:
-        try:
-            if message.embeds[0].fields[1].name == 'took me':
-                await message.add_reaction('❌')
-        except(Exception,):
-            pass
-
+#fallback feature to delete generations if aiya has been restarted
 @self.event
 async def on_raw_reaction_add(ctx):
     if ctx.emoji.name == '❌':

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -54,7 +54,7 @@ def union(list_1, list_2, list_3):
     master_queue = list_1 + list_2 + list_3
     return master_queue
 
-async def process_dream(self, queue_object):
+async def process_dream(self, queue_object, my_view):
     GlobalQueue.dream_thread = Thread(target=self.dream,
-                               args=(GlobalQueue.event_loop, queue_object))
+                               args=(GlobalQueue.event_loop, queue_object, my_view))
     GlobalQueue.dream_thread.start()

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -19,16 +19,31 @@ from core import settings
 from core import upscalecog
 from core import identifycog
 
-
+async def test_button():
+    print("Buttons!")
 class MyView(discord.ui.View):
-    def __init__(self):
+    def __init__(self, user):
         super().__init__(timeout=None)
+        self.user = user
+
     @discord.ui.button(
-        custom_id="button_100",
+        custom_id="button_reroll",
         emoji="🎲")
     async def button_callback(self, button, interaction):
         button.disabled = True
-        await interaction.response.send_message("You clicked the button!")
+        await interaction.response.edit_message(view=self)
+        await test_button()
+
+    @discord.ui.button(
+        custom_id="button_x",
+        emoji="❌")
+    async def delete(self, button, interaction):
+        print(interaction.user.id)
+        print(self.user)
+        if interaction.user.id == self.user:
+            await interaction.message.delete()
+        else:
+            await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
 
 class StableCog(commands.Cog, name='Stable Diffusion', description='Create images from natural language.'):
     ctx_parse = discord.ApplicationContext
@@ -407,7 +422,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             event_loop.create_task(queue_object.ctx.channel.send(embed=embed))
         #check each queue for any remaining tasks
         if queuehandler.GlobalQueue.draw_q:
-            event_loop.create_task(queuehandler.process_dream(self, queuehandler.GlobalQueue.draw_q.pop(0)))
+            event_loop.create_task(queuehandler.process_dream(self, queuehandler.GlobalQueue.draw_q.pop(0), my_view))
         if queuehandler.GlobalQueue.upscale_q:
             upscale_dream = upscalecog.UpscaleCog(self)
             event_loop.create_task(queuehandler.process_dream(upscale_dream, queuehandler.GlobalQueue.upscale_q.pop(0)))

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -277,18 +277,17 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if user_already_in_queue:
                 await ctx.send_response(content=f'Please wait! You\'re queued up.', ephemeral=True)
             else:
-                queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt))
+                queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt), MyView())
                 await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{append_options}')
         else:
-            await queuehandler.process_dream(self, queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt))
+            await queuehandler.process_dream(self, queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt), MyView())
             await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{append_options}')
 
     #generate the image
-    def dream(self, event_loop: AbstractEventLoop, queue_object: queuehandler.DrawObject):
+    def dream(self, event_loop: AbstractEventLoop, queue_object: queuehandler.DrawObject, my_view: View):
         try:
             start_time = time.time()
 
-            view = View()
             #construct a payload for data model, then the normal payload
             model_payload = {
                 "fn_index": settings.global_var.model_fn_index,
@@ -400,7 +399,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
                 files = [discord.File(fp=buffer, filename=f'{queue_object.seed}-{i}.png') for (i, buffer) in enumerate(buffer_handles)]
 
-                event_loop.create_task(queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>', embed=embed, files=files, view=view))
+                event_loop.create_task(queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>', embed=embed, files=files, view=my_view))
 
         except Exception as e:
             embed = discord.Embed(title='txt2img failed', description=f'{e}\n{traceback.print_exc()}',

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -7,18 +7,28 @@ import time
 import traceback
 from asyncio import AbstractEventLoop
 from typing import Optional
-
 import discord
 import requests
 from PIL import Image, PngImagePlugin
 from discord import option
 from discord.ext import commands
+from discord.ui import View
 
 from core import queuehandler
 from core import settings
 from core import upscalecog
 from core import identifycog
 
+
+class MyView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+    @discord.ui.button(
+        custom_id="button_100",
+        emoji="🎲")
+    async def button_callback(self, button, interaction):
+        button.disabled = True
+        await interaction.response.send_message("You clicked the button!")
 
 class StableCog(commands.Cog, name='Stable Diffusion', description='Create images from natural language.'):
     ctx_parse = discord.ApplicationContext
@@ -278,6 +288,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         try:
             start_time = time.time()
 
+            view = View()
             #construct a payload for data model, then the normal payload
             model_payload = {
                 "fn_index": settings.global_var.model_fn_index,
@@ -388,7 +399,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     buffer.seek(0)
 
                 files = [discord.File(fp=buffer, filename=f'{queue_object.seed}-{i}.png') for (i, buffer) in enumerate(buffer_handles)]
-                event_loop.create_task(queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>', embed=embed, files=files))
+
+                event_loop.create_task(queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>', embed=embed, files=files, view=view))
 
         except Exception as e:
             embed = discord.Embed(title='txt2img failed', description=f'{e}\n{traceback.print_exc()}',


### PR DESCRIPTION
This PR will handle part of feature request #19

The idea is that after each generated image, below the embed is a button. When clicking the button, it will generate a new image using the same parameters, but with a new random seed.

What's done:
-Adding a 🎲 button onto the generation message
-Also, a 2nd ❌button to delete the generated image (replacing the ❌ reaction)
-AIYA will know who started the command, so others can't press their generated image's buttons

Need to do:
-The 🎲 needs send another task to the queue to actually perform the feature of this PR
-Fix a bug I just noticed in which whoever starts the queue can press the buttons of every task in the queue. that is to say:
 - Person A starts with a /draw command
 - Before the output is sent, person B does a /draw command
 - There's now two /draws in the queue to be processed
 - Once processed, person A has access to the buttons of both outputs
 - Person B can't do anything
 - This is the same issue preventing PR #39 to be completed and I don't know how to solve it.