### PR TITLE
Use Autocomplete for data_model option

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -29,6 +29,7 @@ class GlobalVar:
     username: Optional[str] = None
     password: Optional[str] = None
     sampler_names = []
+    model_names = {}
     style_names = {}
     facefix_models = []
     copy_command: bool = False
@@ -114,13 +115,20 @@ def files_check():
         if replace_model_file:
             os.remove('resources/models.csv')
             os.rename('resources/models2.csv', 'resources/models.csv')
-    #otherwise create/reformat it
+    #create/reformat model.csv if something is wrong
     if make_model_file:
         print(f'Uh oh, missing models.csv data. Creating a new one.')
         with open('resources/models.csv', 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f, delimiter = "|")
             writer.writerow(header)
             writer.writerow(unset_model)
+
+    #get display_name:model_full_name pairs from models.csv into global variable
+    with open('resources/models.csv', encoding='utf-8') as csv_file:
+        model_data = list(csv.reader(csv_file, delimiter='|'))
+        for row in model_data[1:]:
+            global_var.model_names[row[0]] = row[1]
+    print(global_var.model_names)
 
     #if directory in DIR doesn't exist, create it
     dir_exists = os.path.exists(global_var.dir)

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -1,17 +1,20 @@
-import csv
+import discord
 from discord import option
 from discord.ext import commands
-from discord.commands import OptionChoice
-from core import settings
 from typing import Optional
+
+from core import settings
 
 
 class SettingsCog(commands.Cog):
     def __init__(self, bot:commands.Bot):
         self.bot = bot
 
-    with open('resources/models.csv', encoding='utf-8') as csv_file:
-        model_data = list(csv.reader(csv_file, delimiter='|'))
+    # pulls from model_names list and makes some sort of dynamic list to bypass Discord 25 choices limit
+    def model_autocomplete():
+        return [
+            models for model in settings.global_var.model_names
+        ]
 
     @commands.slash_command(name = 'settings', description = 'Review and change server defaults')
     @option(
@@ -31,7 +34,7 @@ class SettingsCog(commands.Cog):
         str,
         description='Set default data model for image generation',
         required=False,
-        choices=[OptionChoice(name=row[0], value=row[1]) for row in model_data[1:]]
+        autocomplete=discord.utils.basic_autocomplete(model_autocomplete),
     )
     @option(
         'set_steps',


### PR DESCRIPTION
I've been grinding on this project for over a month. Most of the issues left are things beyond my knowledge level and will take a lot of research. 
Taking some time to slow down and actually play around with Stable Diffusion.
In the time I've been focused on this project, the community has been pumping out data models like crazy.
It becomes clear that 25 choice limit for data_model option may not be enough.

This PR uses mostly the same process from PR #42 for the data_model option.
On startup, models.csv is loaded into a global variable. This list can be as big as the user needs.
It's then handled by discord.AutocompleteContext in the cogs.
The data_model choices will still show the first 25 options until user inputs any character.
discord.AutocompleteContext will take that input and return up to 25 matches to display as choices.
Infinite choices!

This is also a decent workaround for a concern I expressed in PR #45, in which I said 
> Some models I've seen have multiple different activation keywords; user can choose to do x or y style. I don't have a good way to handle these use cases.

With no more limit, a user can simply duplicate an entry in models.csv and apply a different activation token. Example:
```
Pixel Sprites|publicPrompts-Pixel-Model.ckpt [916ea38c]|pixelsprite style
Pixel Scenes|publicPrompts-Pixel-Model.ckpt [916ea38c]|16bitscene style
```