### PR TITLE
Add interrogator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ To generate an image from text, use the /draw command and include your prompt as
 - batch count
 - Web UI styles
 - face restoration
-- upscaler
-- identify (create a caption for your image)
 
 #### Bonus features
 
@@ -48,8 +46,10 @@ To generate an image from text, use the /draw command and include your prompt as
   - sampling steps / max steps
   - sampling method
   - batch count / max batch count
+- /identify command - create a caption for your image.
 - /stats command - shows how many /draw commands have been used.
 - /tips command - basic tips for writing prompts.
+- /upscale command - resize your image.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To generate an image from text, use the /draw command and include your prompt as
 - Web UI styles
 - face restoration
 - upscaler
+- identify (create a caption for your image)
 
 #### Bonus features
 

--- a/aiya.py
+++ b/aiya.py
@@ -23,6 +23,7 @@ settings.old_api_check()
 self.load_extension('core.settingscog')
 self.load_extension('core.stablecog')
 self.load_extension('core.upscalecog')
+self.load_extension('core.identifycog')
 self.load_extension('core.tipscog')
 
 #stats slash command

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -1,0 +1,86 @@
+import base64
+import traceback
+import discord
+import requests
+from discord import option
+from discord.ext import commands
+from typing import Optional
+
+from core import settings
+
+
+class IdentifyCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.slash_command(name = 'identify', description = 'Describe an image')
+    @option(
+        'init_image',
+        discord.Attachment,
+        description='The image to identify',
+        required=False,
+    )
+    @option(
+        'init_url',
+        str,
+        description='The URL image to identify. This overrides init_image!',
+        required=False,
+    )
+    async def dream_handler(self, ctx: discord.ApplicationContext, *,
+                            init_image: Optional[discord.Attachment] = None,
+                            init_url: Optional[str]):
+
+        has_image = True
+        #url *will* override init image for compatibility, can be changed here
+        if init_url:
+            try:
+                init_image = requests.get(init_url)
+            except(Exception,):
+                await ctx.send_response('URL image not found!\nI have nothing to work with...', ephemeral=True)
+                has_image = False
+
+        #fail if no image is provided
+        if init_url is None:
+            if init_image is None:
+                await ctx.send_response('I need an image to identify!', ephemeral=True)
+                has_image = False
+
+        if has_image:
+            try:
+                first_embed = discord.Embed(title='Identifying')
+                first_embed.colour = settings.global_var.embed_color
+                await ctx.send_response(embed=first_embed)
+                #construct a payload
+                image = base64.b64encode(requests.get(init_image.url, stream=True).content).decode('utf-8')
+                payload = {
+                    "image": 'data:image/png;base64,' + image
+                }
+
+                #send normal payload to webui
+                with requests.Session() as s:
+                    if settings.global_var.username is not None:
+                        login_payload = {
+                        'username': settings.global_var.username,
+                        'password': settings.global_var.password
+                        }
+                        s.post(settings.global_var.url + '/login', data=login_payload)
+                    else:
+                        s.post(settings.global_var.url + '/login')
+
+                    response = s.post(url=f'{settings.global_var.url}/sdapi/v1/interrogate', json=payload)
+                response_data = response.json()
+
+                # post to discord
+                new_embed = discord.Embed()
+                new_embed.set_image(url=init_image.url)
+                new_embed.colour = settings.global_var.embed_color
+                new_embed.add_field(name=f'I think this is', value=f'``{response_data.get("caption")}``', inline=False)
+                await ctx.edit(embed=new_embed)
+
+            except Exception as e:
+                embed = discord.Embed(title='identify failed', description=f'{e}\n{traceback.print_exc()}',
+                                      color=settings.global_var.embed_color)
+                await ctx.channel.send(embed=embed)
+
+def setup(bot):
+    bot.add_cog(IdentifyCog(bot))

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -34,17 +34,26 @@ class UpscaleObject:
         self.upscaler_2 = upscaler_2
         self.upscaler_2_strength = upscaler_2_strength
 
+#the queue object for extras - upscale
+class IdentifyObject:
+    def __init__(self, ctx, init_image):
+        self.ctx = ctx
+        self.init_image = init_image
+
 #any command that needs to wait on processing should use the dream thread
 class GlobalQueue:
     dream_thread = Thread()
     event_loop = asyncio.get_event_loop()
     master_queue = []
-    draw_queue = []
-    upscale_queue = []
+    draw_q = []
+    upscale_q = []
+    identify_q = []
+
 #this creates the master queue that oversees all queues
-def union(list_1, list_2):
-    master_queue = list_1 + list_2
+def union(list_1, list_2, list_3):
+    master_queue = list_1 + list_2 + list_3
     return master_queue
+
 async def process_dream(self, queue_object):
     GlobalQueue.dream_thread = Thread(target=self.dream,
                                args=(GlobalQueue.event_loop, queue_object))


### PR DESCRIPTION
This PR adds the interrogator function from the API. I'm naming it /identify. Interrogate is a little aggressive sounding

It allows the user to input an image (attachment or URL), and after a moment aiya will create a caption guessing at what the image is of.

This slash command will need to use the queue. Before it can be implemented, I need to solve the issue that's halting progress on PRs #39 and #52 in regards to the queue. 
The issue is: whichever is the 1st task in the queue, all subsequent tasks assume it's the same type of task as the initial task.