### PR TITLE
Reroll with different seed B

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ To generate an image from text, use the /draw command and include your prompt as
 - /stats command - shows how many /draw commands have been used.
 - /tips command - basic tips for writing prompts.
 - /upscale command - resize your image.
+- buttons - certain outputs will contain buttons.
+  - 🎲 - generates a new image with same parameters, different seed.
+  - ❌ - deletes the generated image.
 
 ## Notes
 

--- a/aiya.py
+++ b/aiya.py
@@ -41,16 +41,7 @@ async def on_ready():
     #because guilds are only known when on_ready, run files check for guilds
     settings.guilds_check(self)
 
-#feature to delete generations. give bot 'Add Reactions' permission (or not, to hide the ❌)
-@self.event
-async def on_message(message):
-    if message.author == self.user:
-        try:
-            if message.embeds[0].fields[1].name == 'took me':
-                await message.add_reaction('❌')
-        except(Exception,):
-            pass
-
+#fallback feature to delete generations if aiya has been restarted
 @self.event
 async def on_raw_reaction_add(ctx):
     if ctx.emoji.name == '❌':

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -8,25 +8,11 @@ from discord.ext import commands
 from typing import Optional
 
 from core import queuehandler
+from core import viewhandler
 from core import settings
 from core import stablecog
 from core import upscalecog
 
-
-#creating the view that holds the buttons for /identify output
-class MyView(discord.ui.View):
-    def __init__(self, user):
-        super().__init__(timeout=None)
-        self.user = user
-
-    @discord.ui.button(
-        custom_id="button_x",
-        emoji="❌")
-    async def delete(self, button, interaction):
-        if interaction.user.id == self.user:
-            await interaction.message.delete()
-        else:
-            await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
 
 class IdentifyCog(commands.Cog):
     def __init__(self, bot):
@@ -64,7 +50,7 @@ class IdentifyCog(commands.Cog):
                 await ctx.send_response('I need an image to identify!', ephemeral=True)
                 has_image = False
 
-        view = MyView(ctx.author.id)
+        view = viewhandler.DeleteView(ctx.author.id)
         #set up the queue if an image was found
         if has_image:
             if queuehandler.GlobalQueue.dream_thread.is_alive():

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -13,6 +13,7 @@ from core import stablecog
 from core import upscalecog
 
 
+#creating the view that holds the buttons for /identify output
 class MyView(discord.ui.View):
     def __init__(self, user):
         super().__init__(timeout=None)

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -5,7 +5,7 @@ from threading import Thread
 #the queue object for txt2image and img2img
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed,
-                 strength, init_image, copy_command, batch_count, style, facefix, simple_prompt):
+                 strength, init_image, copy_command, batch_count, style, facefix, simple_prompt, view):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -23,6 +23,7 @@ class DrawObject:
         self.style = style
         self.facefix = facefix
         self.simple_prompt = simple_prompt
+        self.view = view
 
 #the queue object for extras - upscale
 class UpscaleObject:
@@ -36,9 +37,10 @@ class UpscaleObject:
 
 #the queue object for identify (interrogate)
 class IdentifyObject:
-    def __init__(self, ctx, init_image):
+    def __init__(self, ctx, init_image, view):
         self.ctx = ctx
         self.init_image = init_image
+        self.view = view
 
 #any command that needs to wait on processing should use the dream thread
 class GlobalQueue:

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -27,13 +27,14 @@ class DrawObject:
 
 #the queue object for extras - upscale
 class UpscaleObject:
-    def __init__(self, ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength):
+    def __init__(self, ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, view):
         self.ctx = ctx
         self.resize = resize
         self.init_image = init_image
         self.upscaler_1 = upscaler_1
         self.upscaler_2 = upscaler_2
         self.upscaler_2_strength = upscaler_2_strength
+        self.view = view
 
 #the queue object for identify (interrogate)
 class IdentifyObject:

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -11,9 +11,9 @@ class SettingsCog(commands.Cog):
         self.bot = bot
 
     # pulls from model_names list and makes some sort of dynamic list to bypass Discord 25 choices limit
-    def model_autocomplete():
+    def model_autocomplete(self: discord.AutocompleteContext):
         return [
-            models for model in settings.global_var.model_names
+            model for model in settings.global_var.model_names
         ]
 
     @commands.slash_command(name = 'settings', description = 'Review and change server defaults')

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -1,24 +1,49 @@
 import base64
 import contextlib
 import csv
+import discord
 import io
 import random
+import requests
 import time
 import traceback
 from asyncio import AbstractEventLoop
-from typing import Optional
-
-import discord
-import requests
 from PIL import Image, PngImagePlugin
 from discord import option
 from discord.ext import commands
+from typing import Optional
 
+from core import identifycog
 from core import queuehandler
 from core import settings
 from core import upscalecog
-from core import identifycog
 
+
+async def test_button():
+    print("Buttons!")
+class MyView(discord.ui.View):
+    def __init__(self, user):
+        super().__init__(timeout=None)
+        self.user = user
+
+    @discord.ui.button(
+        custom_id="button_reroll",
+        emoji="🎲")
+    async def button_callback(self, button, interaction):
+        button.disabled = True
+        await interaction.response.edit_message(view=self)
+        await test_button()
+
+    @discord.ui.button(
+        custom_id="button_x",
+        emoji="❌")
+    async def delete(self, button, interaction):
+        print(interaction.user.id)
+        print(self.user)
+        if interaction.user.id == self.user:
+            await interaction.message.delete()
+        else:
+            await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
 
 class StableCog(commands.Cog, name='Stable Diffusion', description='Create images from natural language.'):
     ctx_parse = discord.ApplicationContext
@@ -257,6 +282,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             copy_command = copy_command + f' facefix:{facefix}'
         print(copy_command)
 
+        view = MyView(ctx.author.id)
         #setup the queue
         if queuehandler.GlobalQueue.dream_thread.is_alive():
             user_already_in_queue = False
@@ -267,10 +293,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if user_already_in_queue:
                 await ctx.send_response(content=f'Please wait! You\'re queued up.', ephemeral=True)
             else:
-                queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt))
+                queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt, view))
                 await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{append_options}')
         else:
-            await queuehandler.process_dream(self, queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt))
+            await queuehandler.process_dream(self, queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt, view))
             await ctx.send_response(f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{append_options}')
 
     #generate the image
@@ -388,7 +414,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     buffer.seek(0)
 
                 files = [discord.File(fp=buffer, filename=f'{queue_object.seed}-{i}.png') for (i, buffer) in enumerate(buffer_handles)]
-                event_loop.create_task(queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>', embed=embed, files=files))
+                event_loop.create_task(queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>', embed=embed, files=files, view=queue_object.view))
 
         except Exception as e:
             embed = discord.Embed(title='txt2img failed', description=f'{e}\n{traceback.print_exc()}',

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -19,31 +19,65 @@ from core import settings
 from core import upscalecog
 
 
-async def test_button():
-    print("Buttons!")
+#creating the view that holds the buttons for /draw output
 class MyView(discord.ui.View):
-    def __init__(self, user):
+    def __init__(self, input_tuple):
         super().__init__(timeout=None)
-        self.user = user
+        self.input_tuple = input_tuple
 
     @discord.ui.button(
-        custom_id="button_reroll",
-        emoji="🎲")
+        custom_id="button_reroll", emoji="🎲")
     async def button_callback(self, button, interaction):
-        button.disabled = True
-        await interaction.response.edit_message(view=self)
-        await test_button()
+        try:
+            #check if the /draw output is from the person who requested it
+            if self.message.embeds[0].footer.text == f'{interaction.user.name}#{interaction.user.discriminator}':
+                #update the tuple with a new seed
+                new_seed = list(self.input_tuple)
+                new_seed[9] = random.randint(0, 0xFFFFFFFF)
+                self.input_tuple = tuple(new_seed)
 
+                #set up the draw dream and do queue code again for lack of a more elegant solution
+                draw_dream = StableCog(self)
+                if queuehandler.GlobalQueue.dream_thread.is_alive():
+                    user_already_in_queue = False
+                    for queue_object in queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q):
+                        if queue_object.ctx.author.id == interaction.user.id:
+                            user_already_in_queue = True
+                            break
+                    if user_already_in_queue:
+                        await interaction.response.send_message(content=f"Please wait! You're queued up.", ephemeral=True)
+                    else:
+                        button.disabled = True
+                        await interaction.response.edit_message(view=self)
+                        queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(*self.input_tuple, MyView(self.input_tuple)))
+                        await interaction.followup.send(f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew seed:``{new_seed[9]}``')
+                else:
+                    button.disabled = True
+                    await interaction.response.edit_message(view=self)
+                    await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*self.input_tuple, MyView(self.input_tuple)))
+                    await interaction.followup.send(f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew Seed:``{new_seed[9]}``')
+            else:
+                await interaction.response.send_message("You can't use other people's buttons!", ephemeral=True)
+        except:
+            #if interaction fails, assume it's because aiya restarted (breaks buttons)
+            button.disabled = True
+            await interaction.response.edit_message(view=self)
+            await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
+
+    #the button to delete generated images
     @discord.ui.button(
         custom_id="button_x",
         emoji="❌")
     async def delete(self, button, interaction):
-        print(interaction.user.id)
-        print(self.user)
-        if interaction.user.id == self.user:
-            await interaction.message.delete()
-        else:
-            await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
+        try:
+            if self.message.embeds[0].footer.text == f'{interaction.user.name}#{interaction.user.discriminator}':
+                await interaction.message.delete()
+            else:
+                await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
+        except:
+                button.disabled = True
+                await interaction.response.edit_message(view=self)
+                await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
 
 class StableCog(commands.Cog, name='Stable Diffusion', description='Create images from natural language.'):
     ctx_parse = discord.ApplicationContext
@@ -51,6 +85,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         self.wait_message = []
         self.bot = bot
         self.send_model = False
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.bot.add_view(MyView(self))
 
     #pulls from model_names list and makes some sort of dynamic list to bypass Discord 25 choices limit
     def model_autocomplete(self: discord.AutocompleteContext):
@@ -282,7 +320,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             copy_command = copy_command + f' facefix:{facefix}'
         print(copy_command)
 
-        view = MyView(ctx.author.id)
+        input_tuple = (ctx, prompt, negative_prompt, data_model, steps, height, width, guidance_scale, sampler, seed, strength, init_image, copy_command, count, style, facefix, simple_prompt)
+        view = MyView(input_tuple)
         #setup the queue
         if queuehandler.GlobalQueue.dream_thread.is_alive():
             user_already_in_queue = False

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -1,0 +1,81 @@
+import discord
+import random
+
+from core import queuehandler
+from core import stablecog
+
+#creating the view that holds the buttons for /draw output
+class DrawView(discord.ui.View):
+    def __init__(self, input_tuple):
+        super().__init__(timeout=None)
+        self.input_tuple = input_tuple
+
+    @discord.ui.button(
+        custom_id="button_reroll", emoji="🎲")
+    async def button_callback(self, button, interaction):
+        try:
+            #check if the /draw output is from the person who requested it
+            if self.message.embeds[0].footer.text == f'{interaction.user.name}#{interaction.user.discriminator}':
+                #update the tuple with a new seed
+                new_seed = list(self.input_tuple)
+                new_seed[9] = random.randint(0, 0xFFFFFFFF)
+                self.input_tuple = tuple(new_seed)
+
+                #set up the draw dream and do queue code again for lack of a more elegant solution
+                draw_dream = stablecog.StableCog(self)
+                if queuehandler.GlobalQueue.dream_thread.is_alive():
+                    user_already_in_queue = False
+                    for queue_object in queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q):
+                        if queue_object.ctx.author.id == interaction.user.id:
+                            user_already_in_queue = True
+                            break
+                    if user_already_in_queue:
+                        await interaction.response.send_message(content=f"Please wait! You're queued up.", ephemeral=True)
+                    else:
+                        button.disabled = True
+                        await interaction.response.edit_message(view=self)
+                        queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(*self.input_tuple, DrawView(self.input_tuple)))
+                        await interaction.followup.send(f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew seed:``{new_seed[9]}``')
+                else:
+                    button.disabled = True
+                    await interaction.response.edit_message(view=self)
+                    await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*self.input_tuple, DrawView(self.input_tuple)))
+                    await interaction.followup.send(f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew Seed:``{new_seed[9]}``')
+            else:
+                await interaction.response.send_message("You can't use other people's buttons!", ephemeral=True)
+        except:
+            #if interaction fails, assume it's because aiya restarted (breaks buttons)
+            button.disabled = True
+            await interaction.response.edit_message(view=self)
+            await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
+
+    #the button to delete generated images
+    @discord.ui.button(
+        custom_id="button_x",
+        emoji="❌")
+    async def delete(self, button, interaction):
+        try:
+            if self.message.embeds[0].footer.text == f'{interaction.user.name}#{interaction.user.discriminator}':
+                await interaction.message.delete()
+            else:
+                await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
+        except:
+                button.disabled = True
+                await interaction.response.edit_message(view=self)
+                await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
+
+
+#creating the view that holds the buttons for /identify output
+class DeleteView(discord.ui.View):
+    def __init__(self, user):
+        super().__init__(timeout=None)
+        self.user = user
+
+    @discord.ui.button(
+        custom_id="button_x",
+        emoji="❌")
+    async def delete(self, button, interaction):
+        if interaction.user.id == self.user:
+            await interaction.message.delete()
+        else:
+            await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -11,7 +11,8 @@ class DrawView(discord.ui.View):
         self.input_tuple = input_tuple
 
     @discord.ui.button(
-        custom_id="button_reroll", emoji="🎲")
+        custom_id="button_re-roll",
+        emoji="🎲")
     async def button_callback(self, button, interaction):
         try:
             #check if the /draw output is from the person who requested it
@@ -25,7 +26,9 @@ class DrawView(discord.ui.View):
                 draw_dream = stablecog.StableCog(self)
                 if queuehandler.GlobalQueue.dream_thread.is_alive():
                     user_already_in_queue = False
-                    for queue_object in queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q):
+                    for queue_object in queuehandler.union(queuehandler.GlobalQueue.draw_q,
+                                                           queuehandler.GlobalQueue.upscale_q,
+                                                           queuehandler.GlobalQueue.identify_q):
                         if queue_object.ctx.author.id == interaction.user.id:
                             user_already_in_queue = True
                             break
@@ -34,16 +37,20 @@ class DrawView(discord.ui.View):
                     else:
                         button.disabled = True
                         await interaction.response.edit_message(view=self)
-                        queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(*self.input_tuple, DrawView(self.input_tuple)))
-                        await interaction.followup.send(f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew seed:``{new_seed[9]}``')
+                        queuehandler.GlobalQueue.draw_q.append(
+                            queuehandler.DrawObject(*self.input_tuple, DrawView(self.input_tuple)))
+                        await interaction.followup.send(
+                            f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew seed:``{new_seed[9]}``')
                 else:
                     button.disabled = True
                     await interaction.response.edit_message(view=self)
-                    await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*self.input_tuple, DrawView(self.input_tuple)))
-                    await interaction.followup.send(f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew Seed:``{new_seed[9]}``')
+                    await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*self.input_tuple,
+                                                                                         DrawView(self.input_tuple)))
+                    await interaction.followup.send(
+                        f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{new_seed[16]}``\nNew Seed:``{new_seed[9]}``')
             else:
                 await interaction.response.send_message("You can't use other people's buttons!", ephemeral=True)
-        except:
+        except(Exception,):
             #if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)
@@ -59,7 +66,7 @@ class DrawView(discord.ui.View):
                 await interaction.message.delete()
             else:
                 await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
-        except:
+        except(Exception,):
                 button.disabled = True
                 await interaction.response.edit_message(view=self)
                 await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
@@ -76,6 +83,7 @@ class DeleteView(discord.ui.View):
         emoji="❌")
     async def delete(self, button, interaction):
         if interaction.user.id == self.user:
+            button.disabled = True
             await interaction.message.delete()
         else:
             await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)


### PR DESCRIPTION
I think the merging of PRs #39 and #54 broke something with #52 when I tried to rebase it. I'd rather just make a new PR than fix whatever I broke, and this time I'll implement it in a simpler way.

This PR will use Discord Views to provide buttons after generated images.  
For this particular PR, I'll include 2 buttons.
- 🎲 button to generate a new image using the same parameters, but with a new random seed.
- ❌ button to delete a generated image (replacing the ❌ reaction)
  - this button will be added to each command

Once this concept is executed, I'd like to add another button for generating an image with the same seed, but allowing user to change parameters (prompt, etc)
And possibly another button just to review the parameters used to generate the image.