### PR TITLE
Add redraw button 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ To generate an image from text, use the /draw command and include your prompt as
 - /tips command - basic tips for writing prompts.
 - /upscale command - resize your image.
 - buttons - certain outputs will contain buttons.
-  - 🎲 - generates a new image with same parameters, different seed.
+  - 🖋 - edit prompt, then generate a new image with same parameters.
+  - 🎲 - randomize seed, then generate a new image with same parameters.
   - 📋 - view the generated image's information.
   - ❌ - deletes the generated image.
 

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -41,7 +41,7 @@ class DrawModal(Modal):
         )
         self.add_item(
             InputText(
-                label='Input your new negative prompt (optional',
+                label='Input your new negative prompt (optional)',
                 style=discord.InputTextStyle.long,
                 value=input_tuple[2],
                 required=False


### PR DESCRIPTION
This PR adds an additional button to images generated by /draw.

The button is a 🖋️ emoji.
Clicking on the button opens a pop up window allowing user to edit the prompt and negative prompt of the generated image.
The fields will be pre-populated with the current prompt.

After submitting the changes, the task will be sent to the queue with the other parameters kept the same.

This PR closes #19.