### PR TITLE
Add CLIP skip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discord bot interface for Stable Diffusion
 ## Setup requirements
 
 - Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
-  - AIYA is currently tested on commit `98947d173e3f1667eba29c904f681047dea9de90` of the Web UI.
+  - AIYA is currently tested on commit `47a44c7e421b98ca07e92dbf88769b04c9e28f86` of the Web UI.
 - Run the Web UI as local host with api (`COMMANDLINE_ARGS= --listen --api`).
 - Clone this repo.
 - Create a text file in your cloned repo called ".env", formatted like so:
@@ -37,6 +37,7 @@ To generate an image from text, use the /draw command and include your prompt as
 - batch count
 - Web UI styles
 - face restoration
+- CLIP skip
 
 #### Bonus features
 
@@ -46,6 +47,7 @@ To generate an image from text, use the /draw command and include your prompt as
   - sampling steps / max steps
   - sampling method
   - batch count / max batch count
+  - CLIP skip
 - /identify command - create a caption for your image.
 - /stats command - shows how many /draw commands have been used.
 - /tips command - basic tips for writing prompts.

--- a/aiya.py
+++ b/aiya.py
@@ -27,7 +27,7 @@ self.load_extension('core.tipscog')
 
 
 # stats slash command
-@self.slash_command(name='stats', description='How many images has the bot generated?')
+@self.slash_command(name='stats', description='How many images have I generated?')
 async def stats(ctx):
     with open('resources/stats.txt', 'r') as f:
         data = list(map(int, f.readlines()))

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -5,7 +5,7 @@ from threading import Thread
 # the queue object for txt2image and img2img
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed,
-                 strength, init_image, batch_count, style, facefix, simple_prompt, view):
+                 strength, init_image, batch_count, style, facefix, clip_skip, simple_prompt, view):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -21,6 +21,7 @@ class DrawObject:
         self.batch_count = batch_count
         self.style = style
         self.facefix = facefix
+        self.clip_skip = clip_skip
         self.simple_prompt = simple_prompt
         self.view = view
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -18,6 +18,7 @@ template = {
     "max_steps": 50,
     "default_count": 1,
     "max_count": 1,
+    "clip_skip": 1,
     "data_model": ""
 }
 

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -24,7 +24,7 @@ class SettingsCog(commands.Cog):
         required=False,
     )
     @option(
-        'set_nprompt',
+        'set_n_prompt',
         str,
         description='Set default negative prompt for the server',
         required=False,
@@ -44,7 +44,7 @@ class SettingsCog(commands.Cog):
         required=False,
     )
     @option(
-        'set_maxsteps',
+        'set_max_steps',
         int,
         description='Set default maximum steps for the server',
         min_value=1,
@@ -58,7 +58,7 @@ class SettingsCog(commands.Cog):
         required=False,
     )
     @option(
-        'set_maxcount',
+        'set_max_count',
         int,
         description='Set default maximum count for the server',
         min_value=1,
@@ -71,15 +71,23 @@ class SettingsCog(commands.Cog):
         required=False,
         choices=settings.global_var.sampler_names,
     )
+    @option(
+        'set_clip_skip',
+        int,
+        description='Set default CLIP skip for the server',
+        required=False,
+        choices=[x for x in range(1, 13, 1)]
+    )
     async def settings_handler(self, ctx,
                                current_settings: Optional[bool] = False,
-                               set_nprompt: Optional[str] = 'unset',
+                               set_n_prompt: Optional[str] = 'unset',
                                set_model: Optional[str] = None,
                                set_steps: Optional[int] = 1,
-                               set_maxsteps: Optional[int] = 1,
+                               set_max_steps: Optional[int] = 1,
                                set_count: Optional[int] = None,
-                               set_maxcount: Optional[int] = None,
-                               set_sampler: Optional[str] = 'unset'):
+                               set_max_count: Optional[int] = None,
+                               set_sampler: Optional[str] = 'unset',
+                               set_clip_skip: Optional[int] = 0):
         guild = '% s' % ctx.guild_id
         reviewer = settings.read(guild)
         reply = 'Summary:\n'
@@ -89,33 +97,37 @@ class SettingsCog(commands.Cog):
                 reply = reply + str(key) + ": " + str(value) + ", "
 
         # run through each command and update the defaults user selects
-        if set_nprompt != 'unset':
-            settings.update(guild, 'negative_prompt', set_nprompt)
-            reply = reply + f'\nNew default negative prompts is "{set_nprompt}.'
+        if set_n_prompt != 'unset':
+            settings.update(guild, 'negative_prompt', set_n_prompt)
+            reply = reply + f'\nNew default negative prompts is "{set_n_prompt}".'
 
         if set_model is not None:
             settings.update(guild, 'data_model', set_model)
-            reply = reply + f'\nNew default data model is "{set_model}.'
+            reply = reply + f'\nNew default data model is "{set_model}".'
 
         if set_sampler != 'unset':
             settings.update(guild, 'sampler', set_sampler)
-            reply = reply + f'\nNew default sampler is "{set_sampler}.'
+            reply = reply + f'\nNew default sampler is "{set_sampler}".'
 
-        if set_maxsteps != 1:
-            settings.update(guild, 'max_steps', set_maxsteps)
-            reply = reply + f'\nNew max steps value is {set_maxsteps}.'
+        if set_max_steps != 1:
+            settings.update(guild, 'max_steps', set_max_steps)
+            reply = reply + f'\nNew max steps value is {set_max_steps}.'
             # automatically lower default steps if max steps goes below it
-            if set_maxsteps < reviewer['default_steps']:
-                settings.update(guild, 'default_steps', set_maxsteps)
-                reply = reply + f'\nDefault steps value is too high! Lowering to {set_maxsteps}.'
+            if set_max_steps < reviewer['default_steps']:
+                settings.update(guild, 'default_steps', set_max_steps)
+                reply = reply + f'\nDefault steps value is too high! Lowering to {set_max_steps}.'
 
-        if set_maxcount is not None:
-            settings.update(guild, 'max_count', set_maxcount)
-            reply = reply + f'\nNew max count value is {set_maxcount}.'
+        if set_max_count is not None:
+            settings.update(guild, 'max_count', set_max_count)
+            reply = reply + f'\nNew max count value is {set_max_count}.'
             # automatically lower default count if max count goes below it
-            if set_maxcount < reviewer['default_count']:
-                settings.update(guild, 'default_count', set_maxcount)
-                reply = reply + f'\nDefault count value is too high! Lowering to {set_maxcount}.'
+            if set_max_count < reviewer['default_count']:
+                settings.update(guild, 'default_count', set_max_count)
+                reply = reply + f'\nDefault count value is too high! Lowering to {set_max_count}.'
+
+        if set_clip_skip != 0:
+            settings.update(guild, 'clip_skip', set_clip_skip)
+            reply = reply + f'\nNew CLIP skip is {set_clip_skip}.'
 
         # review settings again in case user is trying to set steps/counts and max steps/counts simultaneously
         reviewer = settings.read(guild)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -222,14 +222,14 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         with open('resources/stats.txt', 'w') as f:
             f.write('\n'.join(str(x) for x in data))
 
-        # random messages for bot to say
+        # random messages for aiya to say
         with open('resources/messages.csv') as csv_file:
             message_data = list(csv.reader(csv_file, delimiter='|'))
             message_row_count = len(message_data) - 1
             for row in message_data:
                 self.wait_message.append(row[0])
 
-        # formatting bot initial reply
+        # formatting aiya initial reply
         append_options = ''
         # lower step value to the highest setting if user goes over max steps
         if steps > settings.read(guild)['max_steps']:
@@ -260,6 +260,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             append_options = append_options + f'\nStyle: ``{style}``'
         if facefix != 'None':
             append_options = append_options + f'\nFace restoration: ``{facefix}``'
+        if clip_skip != 1:
+            append_options = append_options + f'\nCLIP skip: ``{clip_skip}``'
 
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -96,14 +96,14 @@ class UpscaleCog(commands.Cog):
         filename, file_ext = splitext(basename(disassembled.path))
         self.file_name = filename
 
-        # random messages for bot to say
+        # random messages for aiya to say
         with open('resources/messages.csv') as csv_file:
             message_data = list(csv.reader(csv_file, delimiter='|'))
             message_row_count = len(message_data) - 1
             for row in message_data:
                 self.wait_message.append(row[0])
 
-        # formatting bot initial reply
+        # formatting aiya initial reply
         append_options = ''
         if upscaler_2:
             append_options = append_options + f'\nUpscaler 2: ``{upscaler_2}``'

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -24,7 +24,8 @@ input_tuple[0] = ctx
 [12] = count
 [13] = style
 [14] = facefix
-[15] = simple_prompt
+[15] = clip_skip
+[16] = simple_prompt
 '''
 
 
@@ -36,7 +37,7 @@ class DrawModal(Modal):
         self.add_item(
             InputText(
                 label='Input your new prompt',
-                value=input_tuple[15],
+                value=input_tuple[16],
                 style=discord.InputTextStyle.long
             )
         )
@@ -51,8 +52,8 @@ class DrawModal(Modal):
 
     async def callback(self, interaction: discord.Interaction):
         new_prompt = list(self.input_tuple)
-        new_prompt[1] = new_prompt[1].replace(new_prompt[15], self.children[0].value)
-        new_prompt[15] = self.children[0].value
+        new_prompt[1] = new_prompt[1].replace(new_prompt[16], self.children[0].value)
+        new_prompt[16] = self.children[0].value
         new_prompt[2] = self.children[1].value
         prompt_tuple = tuple(new_prompt)
 
@@ -144,7 +145,7 @@ class DrawView(View):
                         queuehandler.GlobalQueue.draw_q.append(
                             queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
                         await interaction.followup.send(
-                            f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{seed_tuple[15]}``\nNew seed:``{seed_tuple[9]}``')
+                            f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{seed_tuple[16]}``\nNew seed:``{seed_tuple[9]}``')
                 else:
                     button.disabled = True
                     await interaction.response.edit_message(view=self)
@@ -152,7 +153,7 @@ class DrawView(View):
                     await queuehandler.process_dream(draw_dream,
                                                      queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
                     await interaction.followup.send(
-                        f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{seed_tuple[15]}``\nNew Seed:``{seed_tuple[9]}``')
+                        f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q))}`` - ``{seed_tuple[16]}``\nNew Seed:``{seed_tuple[9]}``')
             else:
                 await interaction.response.send_message("You can't use other people's 🎲!", ephemeral=True)
         except(Exception,):
@@ -180,8 +181,8 @@ class DrawView(View):
             # generate the command for copy-pasting, and also add embed fields
             embed = discord.Embed(title="About the image!", description="")
             embed.colour = settings.global_var.embed_color
-            embed.add_field(name=f'Prompt', value=f'``{rev[15]}``', inline=False)
-            copy_command = f'/draw prompt:{rev[15]} data_model:{model_name} steps:{rev[4]} width:{rev[5]} height:{rev[6]} guidance_scale:{rev[7]} sampler:{rev[8]} seed:{rev[9]} count:{rev[12]} '
+            embed.add_field(name=f'Prompt', value=f'``{rev[16]}``', inline=False)
+            copy_command = f'/draw prompt:{rev[16]} data_model:{model_name} steps:{rev[4]} width:{rev[5]} height:{rev[6]} guidance_scale:{rev[7]} sampler:{rev[8]} seed:{rev[9]}'
             if rev[2] != '':
                 copy_command = copy_command + f' negative_prompt:{rev[2]}'
                 embed.add_field(name=f'Negative prompt', value=f'``{rev[2]}``', inline=False)
@@ -196,12 +197,17 @@ class DrawView(View):
             if rev[11]:
                 # not interested in adding embed fields for strength and init_image
                 copy_command = copy_command + f' strength:{rev[10]} init_url:{rev[11]}'
+            if rev[12] != 1:
+                copy_command = copy_command + f' count:{rev[13]}'
             if rev[13] != 'None':
                 copy_command = copy_command + f' style:{rev[13]}'
                 extra_params = extra_params + f'\nStyle preset: ``{rev[13]}``'
             if rev[14] != 'None':
                 copy_command = copy_command + f' facefix:{rev[14]}'
                 extra_params = extra_params + f'\nFace restoration model: ``{rev[14]}``'
+            if rev[15] != 1:
+                copy_command = copy_command + f' clip_skip:{rev[15]}'
+                extra_params = extra_params + f'\nCLIP skip: ``{rev[15]}``'
             embed.add_field(name=f'Other parameters', value=extra_params, inline=False)
             embed.add_field(name=f'Command for copying', value=f'``{copy_command}``', inline=False)
 


### PR DESCRIPTION
This PR adds CLIP skip as an option for /draw.

As I understand, some models like having a different value for the CLIP skip, though it's also just an interesting parameter to adjust otherwise.

The option will also be added to /settings (with initial default of 1), so any server can set a default of 2 or any other value.

The secondary purpose of this PR is to make it easier in the code to add parameters to "override settings" for the payload to API.