### PR TITLE
Update model swapper to new API

### DIFF
--- a/aiya.py
+++ b/aiya.py
@@ -17,7 +17,6 @@ self.logger = get_logger(__name__)
 # check files and global variables
 settings.startup_check()
 settings.files_check()
-settings.old_api_check()
 
 self.load_extension('core.settingscog')
 self.load_extension('core.stablecog')

--- a/core/settings.py
+++ b/core/settings.py
@@ -34,7 +34,6 @@ class GlobalVar:
     model_names = {}
     style_names = {}
     facefix_models = []
-    model_fn_index = 0
     send_model = False
 
 
@@ -193,31 +192,3 @@ def guilds_check(self):
     else:
         print(f'Setting up settings for DMs, called None.json')
         build("None")
-
-
-# iterate through the old api at /config to get things we need that don't exist in new api
-def old_api_check():
-    with requests.Session() as s:
-        if global_var.username is not None:
-            login_payload = {
-                'username': global_var.username,
-                'password': global_var.password
-            }
-            s.post(global_var.url + '/login', data=login_payload)
-            config_url = s.get(global_var.url + "/config")
-        else:
-            s.post(global_var.url + '/login')
-            config_url = s.get(global_var.url + "/config")
-        old_config = config_url.json()
-        # check all dependencies in config to see if there's a target value
-        # and if there is, match the target value to the id value of component we want
-        # this provides the fn_index needed for the payload to old api
-        for d in range(len(old_config["dependencies"])):
-            try:
-                for c in old_config["components"]:
-                    if old_config["dependencies"][d]["targets"][0] == c["id"] and c["props"].get(
-                            "label") == "Stable Diffusion checkpoint":
-                        global_var.model_fn_index = d
-            except(Exception,):
-                pass
-        print("The fn_index for the model is " + str(global_var.model_fn_index) + "!")

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -302,10 +302,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
             # construct a payload for data model, then the normal payload
             model_payload = {
-                "fn_index": settings.global_var.model_fn_index,
-                "data": [
-                    queue_object.data_model
-                ]
+                "sd_model_checkpoint": queue_object.data_model
             }
             payload = {
                 "prompt": queue_object.prompt,
@@ -362,7 +359,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
                 # only send model payload if one is defined
                 if settings.global_var.send_model:
-                    s.post(url=f'{settings.global_var.url}/api/predict', json=model_payload)
+                    s.post(url=f'{settings.global_var.url}/sdapi/v1/options', json=model_payload)
                 if queue_object.init_image is not None:
                     response = s.post(url=f'{settings.global_var.url}/sdapi/v1/img2img', json=payload)
                 else:


### PR DESCRIPTION
This PR will replace the way I have aiya swap models to the new API. No more need to manually sort through the config. I'll miss that code, though; was quite proud of it.

For end user experience, there should be no noticeable change, I think, aside from maybe 1-2 seconds faster initial startup time.