### PR TITLE
Support api-auth

### DIFF
--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -87,7 +87,7 @@ class IdentifyCog(commands.Cog):
                 if settings.global_var.api_auth:
                     s.auth = (settings.global_var.api_user, settings.global_var.api_pass)
 
-                if settings.global_var.username is not None:
+                if settings.global_var.gradio_auth:
                     login_payload = {
                         'username': settings.global_var.username,
                         'password': settings.global_var.password

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -84,6 +84,9 @@ class IdentifyCog(commands.Cog):
 
             # send normal payload to webui
             with requests.Session() as s:
+                if settings.global_var.api_auth:
+                    s.auth = (settings.global_var.api_user, settings.global_var.api_pass)
+
                 if settings.global_var.username is not None:
                     login_payload = {
                         'username': settings.global_var.username,

--- a/core/settings.py
+++ b/core/settings.py
@@ -90,6 +90,11 @@ def startup_check():
             # lazy method to see if --api-auth commandline argument is set
             if response.status_code == 401:
                 global_var.api_auth = True
+                # lazy method to see if --api-auth credentials are set
+                if not global_var.api_pass:
+                    print('API rejected me! If using --api-auth, '
+                          'please check your .env file for APIUSER and APIPASS values.')
+                    os.system("pause")
             # lazy method to see if --api commandline argument is not set
             if response.status_code == 404:
                 print('API is unreachable! Please check Web UI COMMANDLINE_ARGS for --api.')

--- a/core/settings.py
+++ b/core/settings.py
@@ -186,7 +186,13 @@ def files_check():
     r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
     r3 = s.get(global_var.url + "/sdapi/v1/face-restorers")
     for s1 in r.json():
-        global_var.sampler_names.append(s1['name'])
+        try:
+            global_var.sampler_names.append(s1['name'])
+        except(Exception,):
+            # throw in last exception error for anything that wasn't caught earlier
+            print("Can't connect to API for some reason!"
+                  "Please check your .env URL or credentials.")
+            os.system("pause")
     for s2 in r2.json():
         global_var.style_names[s2['name']] = s2['prompt']
     for s3 in r3.json():

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -352,7 +352,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             payload.update(override_payload)
 
             # send normal payload to webui
-            if settings.global_var.username is not None:
+            if settings.global_var.gradio_auth:
                 login_payload = {
                     'username': settings.global_var.username,
                     'password': settings.global_var.password

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -159,7 +159,7 @@ class UpscaleCog(commands.Cog):
                 if settings.global_var.api_auth:
                     s.auth = (settings.global_var.api_user, settings.global_var.api_pass)
 
-                if settings.global_var.username is not None:
+                if settings.global_var.gradio_auth:
                     login_payload = {
                         'username': settings.global_var.username,
                         'password': settings.global_var.password

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -156,6 +156,9 @@ class UpscaleCog(commands.Cog):
 
             # send normal payload to webui
             with requests.Session() as s:
+                if settings.global_var.api_auth:
+                    s.auth = (settings.global_var.api_user, settings.global_var.api_pass)
+
                 if settings.global_var.username is not None:
                     login_payload = {
                         'username': settings.global_var.username,


### PR DESCRIPTION
Closes #61

This adds support for `--api-auth` commandline argument for webui.
The .env file may have two additional fields
 - APIUSER = 
 - APIPASS = 


Tested these scenarios:
 - `--api` only
   - ✔Works.
   - ✔No adverse effects even if `APIUSER` and `APIPASS` are set in .env
   - ✔No adverse effects even if `USER` and `PASS` are set in .env
 - `--api` and `--api-auth`
   - ✔Works
   - ✔Throws a useful error if `APIUSER` or `APIPASS` are not in .env 
   - ✔No adverse effects even if `USER` and `PASS` are set in .env
 - `--api`, `--api-auth`, and `--share`
   - ✔Works.
   - ✔Throws a useful error if `APIUSER` or `APIPASS` are not in .env 
   - ✔No adverse effects even if `USER` and `PASS` are set in .env
 - `--api`, `--api-auth`, `--share`, and `--gradio-auth`
   - ✔Works.
   - 🤷‍♀️Throws a catch-all error if anything else is wrong
 - `--api` and `--share`
   - ✔Works.
   - ✔No adverse effects even if `APIUSER` and `APIPASS` are set in .env
   - ✔No adverse effects even if `USER` and `PASS` are set in .env
 - `--api`, `--share`, and `--gradio-auth`
   - ✔Works.
   - ✔No adverse effects even if `APIUSER` and `APIPASS` are set in .env
   - 🤷‍♀️Throws a catch-all error if anything else is wrong