### PR TITLE
Add facefix options to upscalecog

### DIFF
--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -29,13 +29,17 @@ class DrawObject:
 
 # the queue object for extras - upscale
 class UpscaleObject:
-    def __init__(self, ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, view):
+    def __init__(self, ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, gfpgan, codeformer,
+                 upscale_first, view):
         self.ctx = ctx
         self.resize = resize
         self.init_image = init_image
         self.upscaler_1 = upscaler_1
         self.upscaler_2 = upscaler_2
         self.upscaler_2_strength = upscaler_2_strength
+        self.gfpgan = gfpgan
+        self.codeformer = codeformer
+        self.upscale_first = upscale_first
         self.view = view
 
 


### PR DESCRIPTION
This is a quick PR to add `GFPGAN visibility`, `CodeFormer visibility`, and `Upscale Before Restoring Faces` to the /upscale command. (Does anyone even use this feature?)
I didn't do much testing aside from, "does anything break when I use these three options"