### PR TITLE
Easier models.csv setup

### DIFF
--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -5,7 +5,8 @@ from threading import Thread
 # the queue object for txt2image and img2img
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed,
-                 strength, init_image, batch_count, style, facefix, highres_fix, clip_skip, simple_prompt, view):
+                 strength, init_image, batch_count, style, facefix, highres_fix, clip_skip, simple_prompt,
+                 model_index, view):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -24,6 +25,7 @@ class DrawObject:
         self.highres_fix = highres_fix
         self.clip_skip = clip_skip
         self.simple_prompt = simple_prompt
+        self.model_index = model_index
         self.view = view
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -36,6 +36,7 @@ class GlobalVar:
     api_pass: Optional[str] = None
     send_model = False
     model_names = {}
+    model_pairs = {}
     sampler_names = []
     style_names = {}
     facefix_models = []
@@ -185,6 +186,7 @@ def files_check():
     r = s.get(global_var.url + "/sdapi/v1/samplers")
     r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
     r3 = s.get(global_var.url + "/sdapi/v1/face-restorers")
+    r4 = s.get(global_var.url + "/sdapi/v1/sd-models")
     for s1 in r.json():
         try:
             global_var.sampler_names.append(s1['name'])
@@ -197,6 +199,8 @@ def files_check():
         global_var.style_names[s2['name']] = s2['prompt']
     for s3 in r3.json():
         global_var.facefix_models.append(s3['name'])
+    for s4 in r4.json():
+        global_var.model_pairs[s4['title']] = s4['model_name']
 
 
 def guilds_check(self):

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -206,6 +206,15 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     # if there's no activator token, remove the extra blank space
                     prompt = prompt.lstrip(' ')
 
+        # if using model short name in csv, find its respective title for payload
+        data_model = data_model.replace('\\', '_').replace('/', '_')
+        simple_model = data_model
+        print(data_model, simple_model)
+        for title, name in settings.global_var.model_pairs.items():
+            if name == data_model:
+                data_model = title
+        print(data_model)
+
         if not settings.global_var.send_model:
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
         else:
@@ -273,7 +282,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (
             ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed, strength,
-            init_image, count, style, facefix, highres_fix, clip_skip, simple_prompt)
+            init_image, count, style, facefix, highres_fix, clip_skip, simple_prompt, simple_model)
         view = viewhandler.DrawView(input_tuple)
         # set up tuple of queues to pass into union()
         queues = (queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -205,15 +205,13 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     prompt = row['activator_token'] + " " + prompt
                     # if there's no activator token, remove the extra blank space
                     prompt = prompt.lstrip(' ')
+                    # get the index of the selected model for later use, subtract one for header
+                    model_index = reader.line_num
 
-        # if using model short name in csv, find its respective title for payload
-        data_model = data_model.replace('\\', '_').replace('/', '_')
-        simple_model = data_model
-        print(data_model, simple_model)
+        # if using model "short name" in csv, find its respective title for payload
         for title, name in settings.global_var.model_pairs.items():
-            if name == data_model:
+            if name == data_model.replace('\\', '_').replace('/', '_'):
                 data_model = title
-        print(data_model)
 
         if not settings.global_var.send_model:
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
@@ -282,7 +280,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (
             ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed, strength,
-            init_image, count, style, facefix, highres_fix, clip_skip, simple_prompt, simple_model)
+            init_image, count, style, facefix, highres_fix, clip_skip, simple_prompt, model_index)
         view = viewhandler.DrawView(input_tuple)
         # set up tuple of queues to pass into union()
         queues = (queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -186,6 +186,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
         # if a model is not selected, do nothing
         model_name = 'Default'
+        model_index = 0
         if data_model is None:
             data_model = settings.read(guild)['data_model']
             if data_model != '':

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -294,18 +294,11 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if user_already_in_queue:
                 await ctx.send_response(content=f'Please wait! You\'re queued up.', ephemeral=True)
             else:
-                queuehandler.GlobalQueue.draw_q.append(
-                    queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps, width, height,
-                                            guidance_scale, sampler, seed, strength, init_image, count, style, facefix,
-                                            highres_fix, clip_skip, simple_prompt, view))
+                queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(*input_tuple, view))
                 await ctx.send_response(
                     f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.union(*queues))}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{reply_adds}')
         else:
-            await queuehandler.process_dream(self,
-                                             queuehandler.DrawObject(ctx, prompt, negative_prompt, data_model, steps,
-                                                                     width, height, guidance_scale, sampler, seed,
-                                                                     strength, init_image, count, style, facefix,
-                                                                     highres_fix, clip_skip, simple_prompt, view))
+            await queuehandler.process_dream(self, queuehandler.DrawObject(*input_tuple, view))
             await ctx.send_response(
                 f'<@{ctx.author.id}>, {self.wait_message[random.randint(0, message_row_count)]}\nQueue: ``{len(queuehandler.union(*queues))}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{reply_adds}')
 

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -130,7 +130,7 @@ class DrawView(View):
             else:
                 await interaction.response.send_message("You can't use other people's 🖋!", ephemeral=True)
         except Exception as e:
-            print('The pen button broke:' + str(e))
+            print('The pen button broke: ' + str(e))
             # if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)
@@ -185,7 +185,7 @@ class DrawView(View):
             else:
                 await interaction.response.send_message("You can't use other people's 🎲!", ephemeral=True)
         except Exception as e:
-            print('The dice roll button broke:' + str(e))
+            print('The dice roll button broke: ' + str(e))
             # if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)
@@ -206,6 +206,11 @@ class DrawView(View):
                     if reader.line_num == rev[18]:
                         model_name = row['display_name']
                         activator_token = row['activator_token']
+                    else:
+                        # fill in dummy data for default models.csv
+                        model_name = 'Default'
+                        rev[3] = 'Unknown'
+                        activator_token = False
 
             # generate the command for copy-pasting, and also add embed fields
             embed = discord.Embed(title="About the image!", description="")
@@ -245,7 +250,7 @@ class DrawView(View):
 
             await interaction.response.send_message(embed=embed, ephemeral=True)
         except Exception as e:
-            print('The clipboard button broke:' + str(e))
+            print('The clipboard button broke: ' + str(e))
             # if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -27,6 +27,7 @@ input_tuple[0] = ctx
 [15] = highres_fix
 [16] = clip_skip
 [17] = simple_prompt
+[18] = simple_model
 '''
 
 # set up tuple of queues to pass into union()
@@ -195,12 +196,14 @@ class DrawView(View):
     async def button_review(self, button, interaction):
         # simpler variable name
         rev = self.input_tuple
+        print(rev[3])
+        print(rev[18])
         try:
             # the tuple will show the model_full_name. Get the associated display_name and activator_token from it.
             with open('resources/models.csv', 'r', encoding='utf-8') as f:
                 reader = csv.DictReader(f, delimiter='|')
                 for row in reader:
-                    if row['model_full_name'] == rev[3]:
+                    if (row['model_full_name'] == rev[3]) or (row['model_full_name'] == rev[18]):
                         model_name = row['display_name']
                         activator_token = row['activator_token']
 
@@ -241,7 +244,8 @@ class DrawView(View):
             embed.add_field(name=f'Command for copying', value=f'``{copy_command}``', inline=False)
 
             await interaction.response.send_message(embed=embed, ephemeral=True)
-        except(Exception,):
+        except Exception as e:
+            print('The clipboard button broke:' + str(e))
             # if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -129,7 +129,8 @@ class DrawView(View):
                     await interaction.response.send_modal(DrawModal(self.input_tuple))
             else:
                 await interaction.response.send_message("You can't use other people's 🖋!", ephemeral=True)
-        except(Exception,):
+        except Exception as e:
+            print('The pen button broke:' + str(e))
             # if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)
@@ -183,7 +184,8 @@ class DrawView(View):
                         f'<@{interaction.user.id}>, redrawing the image!\nQueue: ``{len(queuehandler.union(*queues))}`` - ``{seed_tuple[17]}``\nNew Seed:``{seed_tuple[9]}``')
             else:
                 await interaction.response.send_message("You can't use other people's 🎲!", ephemeral=True)
-        except(Exception,):
+        except Exception as e:
+            print('The dice roll button broke:' + str(e))
             # if interaction fails, assume it's because aiya restarted (breaks buttons)
             button.disabled = True
             await interaction.response.edit_message(view=self)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -27,7 +27,7 @@ input_tuple[0] = ctx
 [15] = highres_fix
 [16] = clip_skip
 [17] = simple_prompt
-[18] = simple_model
+[18] = model_index
 '''
 
 # set up tuple of queues to pass into union()
@@ -196,14 +196,12 @@ class DrawView(View):
     async def button_review(self, button, interaction):
         # simpler variable name
         rev = self.input_tuple
-        print(rev[3])
-        print(rev[18])
         try:
             # the tuple will show the model_full_name. Get the associated display_name and activator_token from it.
             with open('resources/models.csv', 'r', encoding='utf-8') as f:
                 reader = csv.DictReader(f, delimiter='|')
                 for row in reader:
-                    if (row['model_full_name'] == rev[3]) or (row['model_full_name'] == rev[18]):
+                    if reader.line_num == rev[18]:
                         model_name = row['display_name']
                         activator_token = row['activator_token']
 

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -198,6 +198,10 @@ class DrawView(View):
     async def button_review(self, button, interaction):
         # simpler variable name
         rev = self.input_tuple
+        # initial dummy data for a default models.csv
+        model_name = 'Default'
+        full_name = 'Unknown'
+        activator_token = False
         try:
             # the tuple will show the model_full_name. Get the associated display_name and activator_token from it.
             with open('resources/models.csv', 'r', encoding='utf-8') as f:
@@ -205,12 +209,11 @@ class DrawView(View):
                 for row in reader:
                     if reader.line_num == rev[18]:
                         model_name = row['display_name']
+                        full_name = rev[3]
                         activator_token = row['activator_token']
-                    else:
-                        # fill in dummy data for default models.csv
-                        model_name = 'Default'
-                        rev[3] = 'Unknown'
-                        activator_token = False
+
+            # strip any folders from model full name
+            full_name = full_name.split('/', 1)[-1].split('\\', 1)[-1]
 
             # generate the command for copy-pasting, and also add embed fields
             embed = discord.Embed(title="About the image!", description="")
@@ -222,10 +225,10 @@ class DrawView(View):
                 embed.add_field(name=f'Negative prompt', value=f'``{rev[2]}``', inline=False)
             if activator_token:
                 embed.add_field(name=f'Data model',
-                                value=f'Display name - ``{model_name}``\nFull name - ``{rev[3]}``\nActivator token - ``{activator_token}``',
+                                value=f'Display name - ``{model_name}``\nFull name - ``{full_name}``\nActivator token - ``{activator_token}``',
                                 inline=False)
             else:
-                embed.add_field(name=f'Data model', value=f'Display name - ``{model_name}``\nFull name - ``{rev[3]}``',
+                embed.add_field(name=f'Data model', value=f'Display name - ``{model_name}``\nFull name - ``{full_name}``',
                                 inline=False)
             extra_params = f'Sampling steps: ``{rev[4]}``\nSize: ``{rev[5]}x{rev[6]}``\nClassifier-free guidance scale: ``{rev[7]}``\nSampling method: ``{rev[8]}``\nSeed: ``{rev[9]}``'
             if rev[11]:


### PR DESCRIPTION
This PR aims to make setting up the models.csv a little more easy

Currently a line in the csv file needs the *full* model name for the 2nd value. Something like this

```
display_name|model_full_name|activator_token    
SD 1.5|sd-v1-5-pruned-emaonly.ckpt [81761151]|
```

When downloading a new model and adding it to the csv, it's a little tedious because there's not a quick and easy way to know the short hash. I'd like to be able to only enter its name, like this

```
display_name|model_full_name|activator_token
SD 1.5|sd-v1-5-pruned-emaonly|
```

Some concerns:
- It doesn't know the file extension. So if someone has "model.ckpt" and "model.safetensors", aiya will select "model.ckpt". 
- I really don't want to break all the existing models.csv that people may have. I need to find a way for both the normal way and this new way to work simultaneously.
- I've got to make sure that the 📋 button still provides all the information correctly like before.
- Models nested within folders need to be supported as well.
- Probably other things I can't think of at the moment.

At some point, I'd like a better way to edit the models.csv than manually opening it up and entering fields, but I can't think of anything simple and practical.