### PR TITLE
Fix stats not incrementing with buttons

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -48,6 +48,14 @@ class GlobalVar:
 global_var = GlobalVar()
 
 
+def stats_count(number):
+    with open('resources/stats.txt', 'r') as f:
+        data = list(map(int, f.readlines()))
+    data[0] = data[0] + number
+    with open('resources/stats.txt', 'w') as f:
+        f.write('\n'.join(str(x) for x in data))
+
+
 def messages():
     random_message = global_var.wait_message[random.randint(0, global_var.wait_message_count)]
     return random_message
@@ -121,7 +129,7 @@ def files_check():
         message_data = list(csv.reader(csv_file, delimiter='|'))
         for row in message_data:
             global_var.wait_message.append(row[0])
-    global_var.wait_message_count = len(global_var.wait_message)
+    global_var.wait_message_count = len(global_var.wait_message) - 1
 
     # creating files if they don't exist
     if os.path.isfile('resources/stats.txt'):

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -229,13 +229,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             except(Exception,):
                 await ctx.send_response('URL image not found!\nI will do my best without it!')
 
-        # increment number of images generated
-        with open('resources/stats.txt', 'r') as f:
-            data = list(map(int, f.readlines()))
-        data[0] = data[0] + count
-        with open('resources/stats.txt', 'w') as f:
-            f.write('\n'.join(str(x) for x in data))
-
         # formatting aiya initial reply
         reply_adds = ''
         # lower step value to the highest setting if user goes over max steps
@@ -404,6 +397,9 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 file_path = f'{settings.global_var.dir}/{epoch_time}-{queue_object.seed}-{file_name[0:120]}-{i}.png'
                 image.save(file_path, pnginfo=metadata)
                 print(f'Saved image: {file_path}')
+
+            # increment number of images generated
+            settings.stats_count(queue_object.batch_count)
 
             # post to discord
             with contextlib.ExitStack() as stack:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -169,8 +169,7 @@ class DrawView(View):
                         if self.input_tuple[3] != '':
                             settings.global_var.send_model = True
 
-                        queuehandler.GlobalQueue.draw_q.append(
-                            queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
+                        queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
                         await interaction.followup.send(
                             f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.union(*queues))}`` - ``{seed_tuple[17]}``\nNew seed:``{seed_tuple[9]}``')
                 else:
@@ -180,8 +179,7 @@ class DrawView(View):
                     if self.input_tuple[3] != '':
                         settings.global_var.send_model = True
 
-                    await queuehandler.process_dream(draw_dream,
-                                                     queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
+                    await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
                     await interaction.followup.send(
                         f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.union(*queues))}`` - ``{seed_tuple[17]}``\nNew Seed:``{seed_tuple[9]}``')
             else:


### PR DESCRIPTION
This PR fixes a bug in which the /stats command would not increment when using 🖋 or 🎲. Simple fix that should work in theory.

I turn the code to update stats.txt into a function and drop it into settings.py (I just do this to make it more neat).
Call the function right before posting to Discord (in dream function), rather than right after running the /draw command.
As all generations (/draw, 🖋, 🎲) use the dream function, this should work every time with this change.

Closes #72

In this PR, I also do an additional fix to random aiya messages (I hope).