### PR TITLE
Add embeddings list and hypernetworks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To generate an image from text, use the /draw command and include your prompt as
 - face restoration
 - high-res fix
 - CLIP skip
+- hypernetworks
 
 #### Bonus features
 
@@ -51,7 +52,7 @@ To generate an image from text, use the /draw command and include your prompt as
   - CLIP skip
 - /identify command - create a caption for your image.
 - /stats command - shows how many /draw commands have been used.
-- /tips command - basic tips for writing prompts.
+- /tips command - basic tips for writing prompts and other info.
 - /upscale command - resize your image.
 - buttons - certain outputs will contain buttons.
   - 🖋 - edit prompt, then generate a new image with same parameters.

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -6,7 +6,7 @@ from threading import Thread
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed,
                  strength, init_image, batch_count, style, facefix, highres_fix, clip_skip, simple_prompt,
-                 model_index, view):
+                 model_index, hypernet, view):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -26,6 +26,7 @@ class DrawObject:
         self.clip_skip = clip_skip
         self.simple_prompt = simple_prompt
         self.model_index = model_index
+        self.hypernet = hypernet
         self.view = view
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -46,6 +46,8 @@ class GlobalVar:
     sampler_names = []
     style_names = {}
     facefix_models = []
+    embeddings_1 = []
+    embeddings_2 = []
 
 
 global_var = GlobalVar()
@@ -215,6 +217,7 @@ def files_check():
     r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
     r3 = s.get(global_var.url + "/sdapi/v1/face-restorers")
     r4 = s.get(global_var.url + "/sdapi/v1/sd-models")
+    r5 = s.get(global_var.url + "/sdapi/v1/embeddings")
     for s1 in r.json():
         try:
             global_var.sampler_names.append(s1['name'])
@@ -229,6 +232,16 @@ def files_check():
         global_var.facefix_models.append(s3['name'])
     for s4 in r4.json():
         global_var.simple_model_pairs[s4['title']] = s4['model_name']
+    for s5, shape in r5.json()['loaded'].items():
+        if shape['shape'] == 768:
+            global_var.embeddings_1.append(s5)
+        if shape['shape'] == 1024:
+            global_var.embeddings_2.append(s5)
+    for s5, shape in r5.json()['skipped'].items():
+        if shape['shape'] == 768:
+            global_var.embeddings_1.append(s5)
+        if shape['shape'] == 1024:
+            global_var.embeddings_2.append(s5)
 
 
 def guilds_check(self):

--- a/core/settings.py
+++ b/core/settings.py
@@ -22,7 +22,8 @@ template = {
     "sampler": "Euler a",
     "default_count": 1,
     "max_count": 1,
-    "clip_skip": 1
+    "clip_skip": 1,
+    "hypernet": "None"
 }
 
 
@@ -245,6 +246,8 @@ def files_check():
             global_var.embeddings_1.append(s5)
         if shape['shape'] == 1024:
             global_var.embeddings_2.append(s5)
+    # add default "None" hypernetwork as option
+    global_var.hyper_names.append('None')
     for s6 in r6.json():
         global_var.hyper_names.append(s6['name'])
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -48,6 +48,7 @@ class GlobalVar:
     facefix_models = []
     embeddings_1 = []
     embeddings_2 = []
+    hyper_names = []
 
 
 global_var = GlobalVar()
@@ -213,11 +214,13 @@ def files_check():
     else:
         s.post(global_var.url + '/login')
 
+    # load many values from Web UI into global variables
     r = s.get(global_var.url + "/sdapi/v1/samplers")
     r2 = s.get(global_var.url + "/sdapi/v1/prompt-styles")
     r3 = s.get(global_var.url + "/sdapi/v1/face-restorers")
     r4 = s.get(global_var.url + "/sdapi/v1/sd-models")
     r5 = s.get(global_var.url + "/sdapi/v1/embeddings")
+    r6 = s.get(global_var.url + "/sdapi/v1/hypernetworks")
     for s1 in r.json():
         try:
             global_var.sampler_names.append(s1['name'])
@@ -242,6 +245,8 @@ def files_check():
             global_var.embeddings_1.append(s5)
         if shape['shape'] == 1024:
             global_var.embeddings_2.append(s5)
+    for s6 in r6.json():
+        global_var.hyper_names.append(s6['name'])
 
 
 def guilds_check(self):

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -15,6 +15,11 @@ class SettingsCog(commands.Cog):
         return [
             model for model in settings.global_var.model_names
         ]
+    # and for hypernetworks
+    def hyper_autocomplete(self: discord.AutocompleteContext):
+        return [
+            hyper for hyper in settings.global_var.hyper_names
+        ]
 
     @commands.slash_command(name='settings', description='Review and change server defaults')
     @option(
@@ -30,7 +35,7 @@ class SettingsCog(commands.Cog):
         required=False,
     )
     @option(
-        'model',
+        'data_model',
         str,
         description='Set default data model for image generation',
         required=False,
@@ -92,10 +97,17 @@ class SettingsCog(commands.Cog):
         required=False,
         choices=[x for x in range(1, 13, 1)]
     )
+    @option(
+        'hypernet',
+        str,
+        description='Set default hypernetwork model for the server.',
+        required=False,
+        autocomplete=discord.utils.basic_autocomplete(hyper_autocomplete),
+    )
     async def settings_handler(self, ctx,
                                current_settings: Optional[bool] = True,
                                n_prompt: Optional[str] = 'unset',
-                               model: Optional[str] = None,
+                               data_model: Optional[str] = None,
                                steps: Optional[int] = 1,
                                max_steps: Optional[int] = 1,
                                width: Optional[int] = 1,
@@ -103,7 +115,8 @@ class SettingsCog(commands.Cog):
                                sampler: Optional[str] = 'unset',
                                count: Optional[int] = None,
                                max_count: Optional[int] = None,
-                               clip_skip: Optional[int] = 0):
+                               clip_skip: Optional[int] = 0,
+                               hypernet: Optional[str] = None,):
         guild = '% s' % ctx.guild_id
         reviewer = settings.read(guild)
         # create the embed for the reply
@@ -127,9 +140,9 @@ class SettingsCog(commands.Cog):
             new = new + f'\nNegative prompts: ``"{n_prompt}"``'
             set_new = True
 
-        if model is not None:
-            settings.update(guild, 'data_model', model)
-            new = new + f'\nData model: ``"{model}"``'
+        if data_model is not None:
+            settings.update(guild, 'data_model', data_model)
+            new = new + f'\nData model: ``"{data_model}"``'
             set_new = True
 
         if max_steps != 1:
@@ -168,6 +181,11 @@ class SettingsCog(commands.Cog):
         if clip_skip != 0:
             settings.update(guild, 'clip_skip', clip_skip)
             new = new + f'\nCLIP skip: ``{clip_skip}``'
+            set_new = True
+
+        if hypernet is not None:
+            settings.update(guild, 'hypernet', hypernet)
+            new = new + f'\nHypernet: ``"{hypernet}"``'
             set_new = True
 
         # review settings again in case user is trying to set steps/counts and max steps/counts simultaneously

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -180,7 +180,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             facefix: Optional[str] = 'None',
                             highres_fix: Optional[bool] = False,
                             clip_skip: Optional[int] = 0,
-                            hypernet: Optional[str] = 'None'):
+                            hypernet: Optional[str] = None):
 
         settings.global_var.send_model = False
         # update defaults with any new defaults from settingscog
@@ -199,6 +199,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             sampler = settings.read(guild)['sampler']
         if clip_skip == 0:
             clip_skip = settings.read(guild)['clip_skip']
+        if hypernet is None:
+            hypernet = settings.read(guild)['hypernet']
 
         # if a model is not selected, do nothing
         model_name = 'Default'

--- a/core/tipscog.py
+++ b/core/tipscog.py
@@ -85,6 +85,28 @@ class TipsView(View):
         await interaction.response.edit_message(embed=embed_model)
 
     @discord.ui.button(
+        custom_id="button_embed",
+        label="Embeddings list")
+    async def button_embed(self, button, interaction):
+
+        embed_1_list, embed_2_list = '', ''
+        for value in settings.global_var.embeddings_1:
+            if value == '':
+                value = ' '
+            embed_1_list = embed_1_list + f'\n``{value}``'
+        for value in settings.global_var.embeddings_2:
+            if value == '':
+                value = ' '
+            embed_2_list = embed_2_list + f'\n``{value}``'
+        embed_embed = discord.Embed(title="Embeddings list")
+        embed_embed.colour = settings.global_var.embed_color
+
+        embed_embed.add_field(name="SD 1.X embeddings", value=embed_1_list, inline=True)
+        embed_embed.add_field(name="SD 2.X embeddings", value=embed_2_list, inline=True)
+
+        await interaction.response.edit_message(embed=embed_embed)
+
+    @discord.ui.button(
         custom_id="button_about",
         label="About me")
     async def button_about(self, button, interaction):

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -27,6 +27,7 @@ input_tuple[0] = ctx
 [16] = clip_skip
 [17] = simple_prompt
 [18] = model_index
+[19] = hypernet
 '''
 
 # set up tuple of queues to pass into union()
@@ -248,6 +249,9 @@ class DrawView(View):
             if rev[16] != 1:
                 copy_command = copy_command + f' clip_skip:{rev[16]}'
                 extra_params = extra_params + f'\nCLIP skip: ``{rev[16]}``'
+            if rev[19] != 'None':
+                copy_command = copy_command + f' hypernet:{rev[19]}'
+                extra_params = extra_params + f'\nHypernetwork model(hash): ``{rev[19]}``'
             embed.add_field(name=f'Other parameters', value=extra_params, inline=False)
             embed.add_field(name=f'Command for copying', value=f'``{copy_command}``', inline=False)
 


### PR DESCRIPTION
This PR does two things

1. embeddings list
AIYA will pull a list of embeddings from API, conveniently recently added with commit https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/fd4461d44c7256d56889f5b5ed9fb660a859172f
She'll sort through loaded and skipped embeddings and populate two global variables, one for SD 1.x embeddings and one for SD 2.x embeddings.
/tips command will have an additional button that lists all the currently available embeddings (in two columns, for each type of embedding).

2. hypernetworks support
I need to look into what hypernetworks are and how to use them.
The tentative implementation is to add another option to /draw command, and also to /settings command for server defaults
*edit: this is what I did. also updated 📋 button with it too*

This PR closes #79 