### PR TITLE
Add more parameters to 🖋️

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -44,6 +44,7 @@ class GlobalVar:
     model_names = {}
     model_tokens = {}
     simple_model_pairs = {}
+    size_range = range(192, 1088, 64)
     sampler_names = []
     style_names = {}
     facefix_models = []

--- a/core/settings.py
+++ b/core/settings.py
@@ -58,7 +58,7 @@ global_var = GlobalVar()
 def stats_count(number):
     with open('resources/stats.txt', 'r') as f:
         data = list(map(int, f.readlines()))
-    data[0] = data[0] + number
+    data[0] += number
     with open('resources/stats.txt', 'w') as f:
         f.write('\n'.join(str(x) for x in data))
 

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -139,7 +139,7 @@ class SettingsCog(commands.Cog):
             for key, value in cur_set.items():
                 if value == '':
                     value = ' '
-                current = current + f'\n{key} - ``{value}``'
+                current += f'\n{key} - ``{value}``'
             embed.add_field(name=f'Current defaults', value=current, inline=False)
 
         # run function to update embeddings list
@@ -150,73 +150,73 @@ class SettingsCog(commands.Cog):
         # run through each command and update the defaults user selects
         if n_prompt != 'unset':
             settings.update(guild, 'negative_prompt', n_prompt)
-            new = new + f'\nNegative prompts: ``"{n_prompt}"``'
+            new += f'\nNegative prompts: ``"{n_prompt}"``'
             set_new = True
 
         if data_model is not None:
             settings.update(guild, 'data_model', data_model)
-            new = new + f'\nData model: ``"{data_model}"``'
+            new += f'\nData model: ``"{data_model}"``'
             set_new = True
 
         if max_steps != 1:
             settings.update(guild, 'max_steps', max_steps)
-            new = new + f'\nMax steps: ``{max_steps}``'
+            new += f'\nMax steps: ``{max_steps}``'
             # automatically lower default steps if max steps goes below it
             if max_steps < reviewer['default_steps']:
                 settings.update(guild, 'default_steps', max_steps)
-                new = new + f'\nDefault steps is too high! Lowering to ``{max_steps}``.'
+                new += f'\nDefault steps is too high! Lowering to ``{max_steps}``.'
             set_new = True
 
         if width != 1:
             settings.update(guild, 'default_width', width)
-            new = new + f'\nWidth: ``"{width}"``'
+            new += f'\nWidth: ``"{width}"``'
             set_new = True
 
         if height != 1:
             settings.update(guild, 'default_height', height)
-            new = new + f'\nHeight: ``"{height}"``'
+            new += f'\nHeight: ``"{height}"``'
             set_new = True
 
         if sampler != 'unset':
             settings.update(guild, 'sampler', sampler)
-            new = new + f'\nSampler: ``"{sampler}"``'
+            new += f'\nSampler: ``"{sampler}"``'
             set_new = True
 
         if max_count is not None:
             settings.update(guild, 'max_count', max_count)
-            new = new + f'\nMax count: ``{max_count}``'
+            new += f'\nMax count: ``{max_count}``'
             # automatically lower default count if max count goes below it
             if max_count < reviewer['default_count']:
                 settings.update(guild, 'default_count', max_count)
-                new = new + f'\nDefault count is too high! Lowering to ``{max_count}``.'
+                new += f'\nDefault count is too high! Lowering to ``{max_count}``.'
             set_new = True
 
         if clip_skip != 0:
             settings.update(guild, 'clip_skip', clip_skip)
-            new = new + f'\nCLIP skip: ``{clip_skip}``'
+            new += f'\nCLIP skip: ``{clip_skip}``'
             set_new = True
 
         if hypernet is not None:
             settings.update(guild, 'hypernet', hypernet)
-            new = new + f'\nHypernet: ``"{hypernet}"``'
+            new += f'\nHypernet: ``"{hypernet}"``'
             set_new = True
 
         # review settings again in case user is trying to set steps/counts and max steps/counts simultaneously
         reviewer = settings.read(guild)
         if steps != 1:
             if steps > reviewer['max_steps']:
-                new = new + f"\nMax steps is ``{reviewer['max_steps']}``! You can't go beyond it!"
+                new += f"\nMax steps is ``{reviewer['max_steps']}``! You can't go beyond it!"
             else:
                 settings.update(guild, 'default_steps', steps)
-                new = new + f'\nSteps: ``{steps}``'
+                new += f'\nSteps: ``{steps}``'
             set_new = True
 
         if count is not None:
             if count > reviewer['max_count']:
-                new = new + f"\nMax count is ``{reviewer['max_count']}``! You can't go beyond it!"
+                new += f"\nMax count is ``{reviewer['max_count']}``! You can't go beyond it!"
             else:
                 settings.update(guild, 'default_count', count)
-                new = new + f'\nCount: ``{count}``'
+                new += f'\nCount: ``{count}``'
             set_new = True
 
         if set_new:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -79,14 +79,14 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         int,
         description='Width of the generated image.',
         required=False,
-        choices=[x for x in range(192, 1088, 64)]
+        choices=[x for x in settings.global_var.size_range]
     )
     @option(
         'height',
         int,
         description='Height of the generated image.',
         required=False,
-        choices=[x for x in range(192, 1088, 64)]
+        choices=[x for x in settings.global_var.size_range]
     )
     @option(
         'guidance_scale',
@@ -441,6 +441,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     queue_object.ctx.channel.send(content=f'<@{queue_object.ctx.author.id}>, {message}', files=files,
                                                   view=queue_object.view))
 
+        except KeyError:
+            embed = discord.Embed(title='txt2img failed', description=f'An invalid parameter was found!',
+                                  color=settings.global_var.embed_color)
+            event_loop.create_task(queue_object.ctx.channel.send(embed=embed))
         except Exception as e:
             embed = discord.Embed(title='txt2img failed', description=f'{e}\n{traceback.print_exc()}',
                                   color=settings.global_var.embed_color)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -261,7 +261,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         if (width != 512) or (height != 512):
             reply_adds += f'\nSize: ``{width}``x``{height}``'
         if guidance_scale != '7.0':
-            reply_adds += f'\nGuidance Scale: ``{guidance_scale}``'
+            try:
+                float(guidance_scale)
+                reply_adds += f'\nGuidance Scale: ``{guidance_scale}``'
+            except(Exception,):
+                reply_adds += f"\nGuidance Scale can't be ``{guidance_scale}``! Setting to default of `7.0`."
+                guidance_scale = 7.0
         if sampler != 'Euler a':
             reply_adds += f'\nSampler: ``{sampler}``'
         if init_image:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -225,7 +225,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 prompt = prompt.lstrip(' ')
                 break
             # get the index of the selected model for later use
-            model_index = model_index + 1
+            model_index += 1
 
         # if using model "short name" in csv, find its respective title for payload
         for title, name in settings.global_var.simple_model_pairs.items():
@@ -253,34 +253,34 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # lower step value to the highest setting if user goes over max steps
         if steps > settings.read(guild)['max_steps']:
             steps = settings.read(guild)['max_steps']
-            reply_adds = reply_adds + f'\nExceeded maximum of ``{steps}`` steps! This is the best I can do...'
+            reply_adds += f'\nExceeded maximum of ``{steps}`` steps! This is the best I can do...'
         if model_name != 'Default':
-            reply_adds = reply_adds + f'\nModel: ``{model_name}``'
+            reply_adds += f'\nModel: ``{model_name}``'
         if negative_prompt != '':
-            reply_adds = reply_adds + f'\nNegative Prompt: ``{negative_prompt}``'
+            reply_adds += f'\nNegative Prompt: ``{negative_prompt}``'
         if (width != 512) or (height != 512):
-            reply_adds = reply_adds + f'\nSize: ``{width}``x``{height}``'
+            reply_adds += f'\nSize: ``{width}``x``{height}``'
         if guidance_scale != '7.0':
-            reply_adds = reply_adds + f'\nGuidance Scale: ``{guidance_scale}``'
+            reply_adds += f'\nGuidance Scale: ``{guidance_scale}``'
         if sampler != 'Euler a':
-            reply_adds = reply_adds + f'\nSampler: ``{sampler}``'
+            reply_adds += f'\nSampler: ``{sampler}``'
         if init_image:
-            reply_adds = reply_adds + f'\nStrength: ``{strength}``'
-            reply_adds = reply_adds + f'\nURL Init Image: ``{init_image.url}``'
+            reply_adds += f'\nStrength: ``{strength}``'
+            reply_adds += f'\nURL Init Image: ``{init_image.url}``'
         if count != 1:
             max_count = settings.read(guild)['max_count']
             if count > max_count:
                 count = max_count
-                reply_adds = reply_adds + f'\nExceeded maximum of ``{count}`` images! This is the best I can do...'
-            reply_adds = reply_adds + f'\nCount: ``{count}``'
+                reply_adds += f'\nExceeded maximum of ``{count}`` images! This is the best I can do...'
+            reply_adds += f'\nCount: ``{count}``'
         if style != 'None':
-            reply_adds = reply_adds + f'\nStyle: ``{style}``'
+            reply_adds += f'\nStyle: ``{style}``'
         if hypernet != 'None':
-            reply_adds = reply_adds + f'\nHypernet: ``{hypernet}``'
+            reply_adds += f'\nHypernet: ``{hypernet}``'
         if facefix != 'None':
-            reply_adds = reply_adds + f'\nFace restoration: ``{facefix}``'
+            reply_adds += f'\nFace restoration: ``{facefix}``'
         if clip_skip != 1:
-            reply_adds = reply_adds + f'\nCLIP skip: ``{clip_skip}``'
+            reply_adds += f'\nCLIP skip: ``{clip_skip}``'
 
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (

--- a/core/tipscog.py
+++ b/core/tipscog.py
@@ -60,7 +60,7 @@ class TipsView(View):
         for key, value in settings.global_var.style_names.items():
             if value == '':
                 value = ' '
-            style_list = style_list + f'\n{key} - ``{value}``'
+            style_list += f'\n{key} - ``{value}``'
         embed_styles = discord.Embed(title="Styles list", description=style_list)
         embed_styles.colour = settings.global_var.embed_color
 
@@ -78,7 +78,7 @@ class TipsView(View):
             # strip any folders from model full name
             value = value.split('/', 1)[-1].split('\\', 1)[-1]
 
-            model_list = model_list + f'\n{key} - ``{value}``'
+            model_list += f'\n{key} - ``{value}``'
         embed_model = discord.Embed(title="Models list", description=model_list)
         embed_model.colour = settings.global_var.embed_color
 
@@ -93,11 +93,11 @@ class TipsView(View):
         for value in settings.global_var.embeddings_1:
             if value == '':
                 value = ' '
-            embed_1_list = embed_1_list + f'\n``{value}``'
+            embed_1_list += f'\n``{value}``'
         for value in settings.global_var.embeddings_2:
             if value == '':
                 value = ' '
-            embed_2_list = embed_2_list + f'\n``{value}``'
+            embed_2_list += f'\n``{value}``'
         embed_embed = discord.Embed(title="Embeddings list")
         embed_embed.colour = settings.global_var.embed_color
 

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -116,16 +116,16 @@ class UpscaleCog(commands.Cog):
         # formatting aiya initial reply
         reply_adds = ''
         if upscaler_2:
-            reply_adds = reply_adds + f'\nUpscaler 2: ``{upscaler_2}``'
-            reply_adds = reply_adds + f' - Strength: ``{upscaler_2_strength}``'
+            reply_adds += f'\nUpscaler 2: ``{upscaler_2}``'
+            reply_adds += f' - Strength: ``{upscaler_2_strength}``'
 
         # check if resize is within limits
         if float(resize) < 1.0:
             resize = 1.0
-            reply_adds = reply_adds + f"\nResize can't go below 1.0x! Setting it to ``{resize}``."
+            reply_adds += f"\nResize can't go below 1.0x! Setting it to ``{resize}``."
         if float(resize) > 4.0:
             resize = 4.0
-            reply_adds = reply_adds + f"\nResize can't go above 4.0x! Setting it to ``{resize}``."
+            reply_adds += f"\nResize can't go above 4.0x! Setting it to ``{resize}``."
 
         # set up tuple of parameters
         input_tuple = (ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, gfpgan, codeformer, upscale_first)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -107,9 +107,11 @@ class DrawModal(Modal):
         # iterate through extended edit for any changes
         new_model = ''
         new_token = ''
+        model_search = False
         model_found = False
         for line in self.children[3].value.split('\n'):
             if 'data_model:' in line:
+                model_search = True
                 model_index = 0
                 new_model = line.split(':', 1)[1]
                 # jump through hoops to find model full name from display name
@@ -174,6 +176,10 @@ class DrawModal(Modal):
             prompt_output += f'\nNew hypernet: ``{pen[19]}``'
         if str(pen[9]) != str(self.input_tuple[9]):
             prompt_output += f'\nNew seed: ``{pen[9]}``'
+
+        if model_search:
+            if not model_found:
+                prompt_output += f"\nI don't recognize this model: ``{new_model}``"
 
         # check queue again, but now we know user is not in queue
         if queuehandler.GlobalQueue.dream_thread.is_alive():

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -99,8 +99,12 @@ class DrawModal(Modal):
         pen[17] = self.children[0].value
         pen[2] = self.children[1].value
 
-        # update the tuple new seed (random if set to -1)
-        pen[9] = self.children[2].value
+        # update the tuple new seed (random if invalid value set)
+        try:
+            pen[9] = int(self.children[2].value)
+        except ValueError:
+            pen[9] = random.randint(0, 0xFFFFFFFF)
+        print(type(self.children[2].value))
         if (self.children[2].value == "-1") or (self.children[2].value == ""):
             pen[9] = random.randint(0, 0xFFFFFFFF)
 
@@ -158,9 +162,13 @@ class DrawModal(Modal):
                     embed_err.add_field(name=f"`{line.split(':', 1)[1]}` height is no good! These heights I can do.",
                                         value=', '.join(['`%s`' % x for x in settings.global_var.size_range]),
                                         inline=False)
-            # need to add error handling for guidance scale
             if 'guidance_scale:' in line:
-                pen[7] = line.split(':', 1)[1]
+                try:
+                    pen[7] = float(line.split(':', 1)[1])
+                except(Exception,):
+                    invalid_input = True
+                    embed_err.add_field(name=f"`{line.split(':', 1)[1]}` is not valid for the guidance scale!",
+                                        value='Make sure you enter a number.', inline=False)
             if 'sampler:' in line:
                 if line.split(':', 1)[1] in settings.global_var.sampler_names:
                     pen[8] = line.split(':', 1)[1]

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -106,11 +106,12 @@ class DrawModal(Modal):
 
         # iterate through extended edit for any changes
         new_model = ''
+        new_token = ''
+        model_found = False
         for line in self.children[3].value.split('\n'):
             if 'data_model:' in line:
                 model_index = 0
                 new_model = line.split(':', 1)[1]
-                model_found = False
                 # jump through hoops to find model full name from display name
                 for (display, short), (display2, token) in zip(settings.global_var.model_names.items(),
                                                                settings.global_var.model_tokens.items()):
@@ -122,7 +123,6 @@ class DrawModal(Modal):
                                 break
                         # grab the new activator token
                         new_token = f'{token} '.lstrip(' ')
-                        pen[1] = pen[1].replace(pen[1].split(pen[17])[0], new_token)
                         break
                     model_index += 1
                 if model_found:
@@ -144,6 +144,9 @@ class DrawModal(Modal):
                 pen[14] = line.split(':', 1)[1]
             if 'hypernet:' in line:
                 pen[19] = line.split(':', 1)[1]
+
+        if model_found:
+            pen[1] = new_token + pen[17]
 
         prompt_tuple = tuple(pen)
 


### PR DESCRIPTION
This PR adds a few extra parameters to edit via the 🖋️ modal.

This is a sorta haphazard, makeshift solution until (if) Discord provides better functionality to modals (I'd really like dropdowns in modals). The extra parameters are freehand editing, so user must ensure they're entering valid values.

The extra parameters currently are (more may be added later):
- data model
- steps
- width
- height
- guidance scale
- sampler
- style
- facefix
- hypernetwork

To do:
- basic error handling

A sample of how it'll look in the modal
![image](https://user-images.githubusercontent.com/2993060/210766795-1328adfe-0a9f-479b-9421-7c63c3b97a68.png)
