### PR TITLE
Rework highres fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To generate an image from text, use the /draw command and include your prompt as
 - As /settings can be abused, consider reviewing who can access the command. This can be done through Apps -> Integrations in your Server Settings.
 - [See wiki for optional .env variables you can set.](https://github.com/Kilvoctu/aiyabot/wiki/.env-Settings)
 - [See wiki for notes on swapping models.](https://github.com/Kilvoctu/aiyabot/wiki/Model-swapping)
+- AIYA uses Web UI's legacy high-res fix method. To ensure this works correctly, in your Web UI settings, enable this option: `For hires fix, use width/height sliders to set final resolution rather than first pass`
 
 
 ## Credits

--- a/core/settings.py
+++ b/core/settings.py
@@ -52,6 +52,7 @@ class GlobalVar:
     embeddings_2 = []
     hyper_names = []
     upscaler_names = []
+    hires_upscaler_names = []
 
 
 global_var = GlobalVar()
@@ -264,14 +265,15 @@ def populate_global_vars():
         for c in old_config['components']:
             try:
                 if c['props']:
-                    # note: 'txt2img_hr_upscaler' pulls the upscaler list for Hires. fix
-                    # I may want those later but for now, only get 'extras_upscaler_1'
                     if c['props']['elem_id'] == 'extras_upscaler_1':
                         global_var.upscaler_names = c['props']['choices']
+                    if c['props']['elem_id'] == 'txt2img_hr_upscaler':
+                        global_var.hires_upscaler_names = c['props']['choices']
             except(Exception,):
                 pass
     except(Exception,):
         print("Trouble accessing Web UI config! I can't pull the upscaler list")
+    global_var.hires_upscaler_names.append('Disabled')
 
 
 def guilds_check(self):

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -369,6 +369,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     "enable_hr": True,
                     "hr_upscaler": queue_object.highres_fix,
                     "hr_scale": 1,
+                    "hr_second_pass_steps": queue_object.steps/2,
                     "denoising_strength": queue_object.strength
                 }
                 payload.update(highres_payload)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -48,6 +48,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             hyper for hyper in settings.global_var.hyper_names
         ]
 
+    # and upscalers for highres fix
+    def hires_autocomplete(self: discord.AutocompleteContext):
+        return [
+            hires for hires in settings.global_var.hires_upscaler_names
+        ]
+
     @commands.slash_command(name='draw', description='Create an image')
     @option(
         'prompt',
@@ -124,9 +130,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
     )
     @option(
         'highres_fix',
-        bool,
-        description='Tries to fix issues from generating high-res images. Takes longer!',
+        str,
+        description='Tries to fix issues from generating high-res images. Recommended: Latent (nearest).',
         required=False,
+        autocomplete=discord.utils.basic_autocomplete(hires_autocomplete),
     )
     @option(
         'clip_skip',
@@ -175,7 +182,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             seed: Optional[int] = -1,
                             style: Optional[str] = 'None',
                             facefix: Optional[str] = 'None',
-                            highres_fix: Optional[bool] = False,
+                            highres_fix: Optional[str] = 'Disabled',
                             clip_skip: Optional[int] = 0,
                             hypernet: Optional[str] = None,
                             strength: Optional[str] = '0.75',
@@ -357,9 +364,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 payload.update(img_payload)
 
             # update payload if high-res fix is used
-            if queue_object.highres_fix:
+            if queue_object.highres_fix != 'Disabled':
                 highres_payload = {
-                    "enable_hr": queue_object.highres_fix,
+                    "enable_hr": True,
+                    "hr_upscaler": queue_object.highres_fix,
                     "hr_scale": 1,
                     "denoising_strength": queue_object.strength
                 }


### PR DESCRIPTION
This PR makes some adjustments to the **highres_fix** option in /draw, according to the recent changes to Web UI.

Currently, AIYA's **highres_fix** is simply `True` or `False`.
The tentative change is having the list of upscalers used by the Web UI change, with `Disabled` acting as `False`, like this
![image](https://user-images.githubusercontent.com/2993060/211888901-3e3fd80b-dd1d-410f-8b01-448ecd1dacc9.png)


That said, I don't know how the new Web UI highres fix works. When experimenting in Web UI, I'm getting the same outputs regardless of whether it's disabled or enabled, for every upscaler used. Further research is required.

edit:
Any hosts will want to enable this in Web UI -> Settings -> Compatibility
![image](https://user-images.githubusercontent.com/2993060/211891699-c09e7d35-0f2a-4fd3-b97d-cf7d89ca454a.png)
I'm not interested in implementing the new highres fix workflow, since it's way too many options to fiddle around for /draw