### PR TITLE
Refactor model handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discord bot interface for Stable Diffusion
 ## Setup requirements
 
 - Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
-  - AIYA is currently tested on commit `3e20244b0fea10988cf5ad8a2fbe190ac47a5049` of the Web UI.
+  - AIYA is currently tested on commit `ce9827a7c51a9f69bf62c634e35d34fa75ee1833` of the Web UI.
 - Run the Web UI as local host with api (`COMMANDLINE_ARGS= --listen --api`).
 - Clone this repo.
 - Create a text file in your cloned repo called ".env", formatted like so:

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -6,7 +6,7 @@ from threading import Thread
 class DrawObject:
     def __init__(self, ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed,
                  strength, init_image, batch_count, style, facefix, highres_fix, clip_skip, simple_prompt,
-                 model_index, hypernet, view):
+                 hypernet, view):
         self.ctx = ctx
         self.prompt = prompt
         self.negative_prompt = negative_prompt
@@ -25,7 +25,6 @@ class DrawObject:
         self.highres_fix = highres_fix
         self.clip_skip = clip_skip
         self.simple_prompt = simple_prompt
-        self.model_index = model_index
         self.hypernet = hypernet
         self.view = view
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -247,8 +247,12 @@ def populate_global_vars():
     for s5 in r5.json():
         global_var.hyper_names.append(s5['name'])
 
-    # create nested dict for models. for each display_name in models.csv, add these values
-    # [0] = title (filename), [1] = name, [2] = shorthash, [3] = activation token
+    # create nested dict for models based on display_name in models.csv
+    # model_info[0] = display name (top level)
+    # model_info[1][0] = filename. this is sent to the API
+    # model_info[1][1] = name of the model
+    # model_info[1][2] = shorthash
+    # model_info[1][3] = activator token
     with open('resources/models.csv', encoding='utf-8') as csv_file:
         model_data = list(csv.reader(csv_file, delimiter='|'))
         for row in model_data[1:]:

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -13,7 +13,7 @@ class SettingsCog(commands.Cog):
     # pulls from model_names list and makes some sort of dynamic list to bypass Discord 25 choices limit
     def model_autocomplete(self: discord.AutocompleteContext):
         return [
-            model for model in settings.global_var.model_names
+            model for model in settings.global_var.model_info
         ]
     # and for hypernetworks
 
@@ -151,9 +151,7 @@ class SettingsCog(commands.Cog):
 
         # run function to update global variables
         if refresh:
-            settings.global_var.model_names.clear()
-            settings.global_var.model_tokens.clear()
-            settings.global_var.simple_model_pairs.clear()
+            settings.global_var.model_info.clear()
             settings.global_var.sampler_names.clear()
             settings.global_var.facefix_models.clear()
             settings.global_var.style_names.clear()

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -214,7 +214,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
         # if a model is not selected, do nothing
         model_name = 'Default'
-        model_index = 0
         if data_model is None:
             data_model = settings.read(guild)['data_model']
             if data_model != '':
@@ -233,8 +232,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 if model[1][3]:
                     prompt = model[1][3] + " " + prompt
                 break
-            # get the index of the selected model for later use
-            model_index += 1
 
         if not settings.global_var.send_model:
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
@@ -294,7 +291,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (
             ctx, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed, strength,
-            init_image, count, style, facefix, highres_fix, clip_skip, simple_prompt, model_index, hypernet)
+            init_image, count, style, facefix, highres_fix, clip_skip, simple_prompt, hypernet)
+        print(input_tuple)
         view = viewhandler.DrawView(input_tuple)
         # set up tuple of queues to pass into union()
         queues = (queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q)

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -33,7 +33,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
     # this also updates list when using /settings "refresh" option
     def model_autocomplete(self: discord.AutocompleteContext):
         return [
-            model for model in settings.global_var.model_names
+            model for model in settings.global_var.model_info
         ]
 
     # and for styles
@@ -224,23 +224,17 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
         simple_prompt = prompt
         # take selected data_model and get model_name, then update data_model with the full name
-        for (key, value), (key2, value2) in zip(settings.global_var.model_names.items(),
-                                                settings.global_var.model_tokens.items()):
-            if key == data_model:
-                model_name = key
-                data_model = value
+        for model in settings.global_var.model_info.items():
+            if model[0] == data_model:
+                model_name = model[0]
+                # go one deeper into nest and grab model full name to send to API
+                data_model = model[1][0]
                 # look at the model for activator token and prepend prompt with it
-                prompt = value2 + " " + prompt
-                # if there's no activator token, remove the extra blank space
-                prompt = prompt.lstrip(' ')
+                if model[1][3]:
+                    prompt = model[1][3] + " " + prompt
                 break
             # get the index of the selected model for later use
             model_index += 1
-
-        # if using model "short name" in csv, find its respective title for payload
-        for title, name in settings.global_var.simple_model_pairs.items():
-            if name == data_model.replace('\\', '_').replace('/', '_'):
-                data_model = title
 
         if not settings.global_var.send_model:
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')

--- a/core/tipscog.py
+++ b/core/tipscog.py
@@ -72,13 +72,10 @@ class TipsView(View):
     async def button_model(self, button, interaction):
 
         model_list = ''
-        for key, value in settings.global_var.model_names.items():
-            if value == '':
-                value = ' '
+        for model in settings.global_var.model_info.items():
             # strip any folders from model full name
-            value = value.split('/', 1)[-1].split('\\', 1)[-1]
-
-            model_list += f'\n{key} - ``{value}``'
+            filename = model[1][0].split('/', 1)[-1].split('\\', 1)[-1]
+            model_list += f'\n{model[0]} - ``{filename}``'
         embed_model = discord.Embed(title="Models list", description=model_list)
         embed_model.colour = settings.global_var.embed_color
 


### PR DESCRIPTION
This PR reworks some of the code around handling models.
**This will break any models.csv formatted in the old way**

Due to a recent commit on Web UI (I think it's this one [a95f1353089bdeaccd7c266b40cdd79efedfe632](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/a95f1353089bdeaccd7c266b40cdd79efedfe632) or one of the ones shortly after), the models are not displayed with hash anymore.
![image](https://user-images.githubusercontent.com/2993060/212527298-7f47cb29-9a21-4ce6-9cdb-e579f1bc3541.png)
In addition to that, sha256 hashes are used now.  

What this means is that the old way to fill models.csv is now broken, because it can't communicate properly through the API. Also, my instructions are out-of-date. My solution is:
- Update the process to fill in models.csv, and update wiki (https://github.com/Kilvoctu/aiyabot/wiki/Model-swapping)
- Refactor code to support only the new process (and simplify code a bit)