### PR TITLE
Refactor queue, performance improvements

### DIFF
--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -15,8 +15,6 @@ from urllib.parse import urlparse
 from core import queuehandler
 from core import viewhandler
 from core import settings
-from core import stablecog
-from core import identifycog
 
 
 class UpscaleCog(commands.Cog):
@@ -144,26 +142,24 @@ class UpscaleCog(commands.Cog):
         # set up tuple of parameters
         input_tuple = (ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, gfpgan, codeformer, upscale_first)
         view = viewhandler.DeleteView(ctx.author.id)
-        # set up tuple of queues to pass into union()
-        queues = (queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q)
         # set up the queue if an image was found
         if has_image:
             if queuehandler.GlobalQueue.dream_thread.is_alive():
                 user_already_in_queue = False
-                for queue_object in queuehandler.union(*queues):
+                for queue_object in queuehandler.GlobalQueue.queue:
                     if queue_object.ctx.author.id == ctx.author.id:
                         user_already_in_queue = True
                         break
                 if user_already_in_queue:
                     await ctx.send_response(content=f'Please wait! You\'re queued up.', ephemeral=True)
                 else:
-                    queuehandler.GlobalQueue.upscale_q.append(queuehandler.UpscaleObject(*input_tuple, view))
+                    queuehandler.GlobalQueue.queue.append(queuehandler.UpscaleObject(self, *input_tuple, view))
                     await ctx.send_response(
-                        f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.union(*queues))}`` - Scale: ``{resize}``x - Upscaler: ``{upscaler_1}``{reply_adds}')
+                        f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - Scale: ``{resize}``x - Upscaler: ``{upscaler_1}``{reply_adds}')
             else:
-                await queuehandler.process_dream(self, queuehandler.UpscaleObject(*input_tuple, view))
+                await queuehandler.process_dream(self, queuehandler.UpscaleObject(self, *input_tuple, view))
                 await ctx.send_response(
-                    f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.union(*queues))}`` - Scale: ``{resize}``x - Upscaler: ``{upscaler_1}``{reply_adds}')
+                    f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - Scale: ``{resize}``x - Upscaler: ``{upscaler_1}``{reply_adds}')
 
     # generate the image
     def dream(self, event_loop: AbstractEventLoop, queue_object: queuehandler.UpscaleObject):
@@ -235,15 +231,7 @@ class UpscaleCog(commands.Cog):
                                   color=settings.global_var.embed_color)
             event_loop.create_task(queue_object.ctx.channel.send(embed=embed))
         # check each queue for any remaining tasks
-        if queuehandler.GlobalQueue.draw_q:
-            draw_dream = stablecog.StableCog(self)
-            event_loop.create_task(queuehandler.process_dream(draw_dream, queuehandler.GlobalQueue.draw_q.pop(0)))
-        if queuehandler.GlobalQueue.upscale_q:
-            event_loop.create_task(queuehandler.process_dream(self, queuehandler.GlobalQueue.upscale_q.pop(0)))
-        if queuehandler.GlobalQueue.identify_q:
-            identify_dream = identifycog.IdentifyCog(self)
-            event_loop.create_task(
-                queuehandler.process_dream(identify_dream, queuehandler.GlobalQueue.identify_q.pop(0)))
+        queuehandler.process_queue()
 
 
 def setup(bot):

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -223,13 +223,13 @@ class DrawModal(Modal):
             if queuehandler.GlobalQueue.dream_thread.is_alive():
                 if self.input_tuple[3] != '':
                     settings.global_var.send_model = True
-                queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(*prompt_tuple, DrawView(prompt_tuple)))
+                queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(stablecog.StableCog(self), *prompt_tuple, DrawView(prompt_tuple)))
                 await interaction.response.send_message(
                     f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``{prompt_output}')
             else:
                 if self.input_tuple[3] != '':
                     settings.global_var.send_model = True
-                await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*prompt_tuple, DrawView(prompt_tuple)))
+                await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(stablecog.StableCog(self), *prompt_tuple, DrawView(prompt_tuple)))
                 await interaction.response.send_message(
                     f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``{prompt_output}')
 
@@ -304,8 +304,7 @@ class DrawView(View):
                         if self.input_tuple[3] != '':
                             settings.global_var.send_model = True
 
-                        queuehandler.GlobalQueue.queue.append(
-                            queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
+                        queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(stablecog.StableCog(self), *seed_tuple, DrawView(seed_tuple)))
                         await interaction.followup.send(
                             f'<@{interaction.user.id}>, {settings.messages()}\nQueue: '
                             f'``{len(queuehandler.GlobalQueue.queue)}`` - ``{seed_tuple[17]}``'
@@ -317,8 +316,7 @@ class DrawView(View):
                     if self.input_tuple[3] != '':
                         settings.global_var.send_model = True
 
-                    await queuehandler.process_dream(draw_dream,
-                                                     queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
+                    await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(stablecog.StableCog(self), *seed_tuple, DrawView(seed_tuple)))
                     await interaction.followup.send(
                         f'<@{interaction.user.id}>, {settings.messages()}\nQueue: '
                         f'``{len(queuehandler.GlobalQueue.queue)}`` - ``{seed_tuple[17]}``'

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -31,8 +31,6 @@ input_tuple[0] = ctx
 tuple_names = ['ctx', 'prompt', 'negative_prompt', 'data_model', 'steps', 'width', 'height', 'guidance_scale',
                'sampler', 'seed', 'strength', 'init_image', 'batch_count', 'style', 'facefix', 'highres_fix',
                'clip_skip', 'simple_prompt', 'hypernet']
-# set up tuple of queues to pass into union()
-queues = (queuehandler.GlobalQueue.draw_q, queuehandler.GlobalQueue.upscale_q, queuehandler.GlobalQueue.identify_q)
 
 
 # the modal that is used for the 🖋 button
@@ -225,15 +223,15 @@ class DrawModal(Modal):
             if queuehandler.GlobalQueue.dream_thread.is_alive():
                 if self.input_tuple[3] != '':
                     settings.global_var.send_model = True
-                queuehandler.GlobalQueue.draw_q.append(queuehandler.DrawObject(*prompt_tuple, DrawView(prompt_tuple)))
+                queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(*prompt_tuple, DrawView(prompt_tuple)))
                 await interaction.response.send_message(
-                    f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.union(*queues))}``{prompt_output}')
+                    f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``{prompt_output}')
             else:
                 if self.input_tuple[3] != '':
                     settings.global_var.send_model = True
                 await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(*prompt_tuple, DrawView(prompt_tuple)))
                 await interaction.response.send_message(
-                    f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.union(*queues))}``{prompt_output}')
+                    f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``{prompt_output}')
 
 
 # creating the view that holds the buttons for /draw output
@@ -254,7 +252,7 @@ class DrawView(View):
                 # if there's room in the queue, open up the modal
                 if queuehandler.GlobalQueue.dream_thread.is_alive():
                     user_already_in_queue = False
-                    for queue_object in queuehandler.union(*queues):
+                    for queue_object in queuehandler.GlobalQueue.queue:
                         if queue_object.ctx.author.id == interaction.user.id:
                             user_already_in_queue = True
                             break
@@ -292,7 +290,7 @@ class DrawView(View):
                 draw_dream = stablecog.StableCog(self)
                 if queuehandler.GlobalQueue.dream_thread.is_alive():
                     user_already_in_queue = False
-                    for queue_object in queuehandler.union(*queues):
+                    for queue_object in queuehandler.GlobalQueue.queue:
                         if queue_object.ctx.author.id == interaction.user.id:
                             user_already_in_queue = True
                             break
@@ -306,11 +304,11 @@ class DrawView(View):
                         if self.input_tuple[3] != '':
                             settings.global_var.send_model = True
 
-                        queuehandler.GlobalQueue.draw_q.append(
+                        queuehandler.GlobalQueue.queue.append(
                             queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
                         await interaction.followup.send(
                             f'<@{interaction.user.id}>, {settings.messages()}\nQueue: '
-                            f'``{len(queuehandler.union(*queues))}`` - ``{seed_tuple[17]}``'
+                            f'``{len(queuehandler.GlobalQueue.queue)}`` - ``{seed_tuple[17]}``'
                             f'\nNew seed:``{seed_tuple[9]}``')
                 else:
                     button.disabled = True
@@ -323,7 +321,7 @@ class DrawView(View):
                                                      queuehandler.DrawObject(*seed_tuple, DrawView(seed_tuple)))
                     await interaction.followup.send(
                         f'<@{interaction.user.id}>, {settings.messages()}\nQueue: '
-                        f'``{len(queuehandler.union(*queues))}`` - ``{seed_tuple[17]}``'
+                        f'``{len(queuehandler.GlobalQueue.queue)}`` - ``{seed_tuple[17]}``'
                         f'\nNew Seed:``{seed_tuple[9]}``')
             else:
                 await interaction.response.send_message("You can't use other people's 🎲!", ephemeral=True)
@@ -364,7 +362,7 @@ class DrawView(View):
             embed.colour = settings.global_var.embed_color
             embed.add_field(name=f'Prompt', value=f'``{rev[17]}``', inline=False)
             embed.add_field(name='Data model', value=f'Display name - ``{model_name}``\nFilename - ``{filename}``'
-                                      f'\nShorthash - ``{model_hash}``{activator_token}', inline=False)
+                                                     f'\nShorthash - ``{model_hash}``{activator_token}', inline=False)
 
             copy_command = f'/draw prompt:{rev[17]} data_model:{model_name} steps:{rev[4]} width:{rev[5]} ' \
                            f'height:{rev[6]} guidance_scale:{rev[7]} sampler:{rev[8]} seed:{rev[9]}'


### PR DESCRIPTION
This PR aims to cleanup code regarding queue while also improving overall AIYA speeds (the fastest!)

---

The queuehandler and cogs that interact with it has been simplifed to revolve around a single better function, removing much redundant and duplicated code. This change brings the required Python version to minimum Python 3.10. This version is already in the Web UI instructions, so I'm not too concerned about this new requirement.

-----

Currently, when AIYA takes a slash command she does two things:
1. Send command to Web UI, wait for response
2. Send response to Discord, wait for it to post

When handling many commands, AIYA will always wait for 2 to finish before handling the next 1.
This PR aims to split each of these two tasks into separate concurrent threads.
In essence, AIYA should be able to continually send commands to Web UI with no waiting. Once Web UI finishes a task, the response is placed into a separate queue that AIYA handles as it fills up.

This theoretically should substantially increase AIYA's speed in practice.
On my machine, it takes 3-10 seconds after an image is generated for it to post on Discord. This downtime should now be gone.

---

To do:
- Testing
There are a lot of changes, and any number of unforeseen things can break.