### PR TITLE
Update model display

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discord bot interface for Stable Diffusion
 ## Setup requirements
 
 - Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
-  - AIYA is currently tested on commit `ce9827a7c51a9f69bf62c634e35d34fa75ee1833` of the Web UI.
+  - AIYA is currently tested on commit `c1928cdd6194928af0f53f70c51d59479b7025e2` of the Web UI.
 - Run the Web UI as local host with api (`COMMANDLINE_ARGS= --listen --api`).
 - Clone this repo.
 - Create a text file in your cloned repo called ".env", formatted like so:

--- a/core/settings.py
+++ b/core/settings.py
@@ -252,7 +252,7 @@ def populate_global_vars():
 
     # create nested dict for models based on display_name in models.csv
     # model_info[0] = display name (top level)
-    # model_info[1][0] = filename. this is sent to the API
+    # model_info[1][0] = "title". this is sent to the API
     # model_info[1][1] = name of the model
     # model_info[1][2] = shorthash
     # model_info[1][3] = activator token

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -63,14 +63,14 @@ class DrawModal(Modal):
         )
 
         # set up parameters for full edit mode. first get model display name
-        model_name = 'Default'
+        display_name = 'Default'
         index_start = 4
         for model in settings.global_var.model_info.items():
             if model[1][0] == input_tuple[3]:
-                model_name = model[0]
+                display_name = model[0]
                 break
         # expose each available (supported) option, even if output didn't use them
-        ex_params = f'data_model:{model_name}'
+        ex_params = f'data_model:{display_name}'
         for index, value in enumerate(tuple_names[index_start:], index_start):
             if 9 <= index <= 12 or index == 15 or index == 17:
                 continue
@@ -338,31 +338,31 @@ class DrawView(View):
         # simpler variable name
         rev = self.input_tuple
         # initial dummy data for a default models.csv
-        model_name = 'Default'
-        filename, model_hash = 'Unknown', 'Unknown'
+        display_name = 'Default'
+        model_name, model_hash = 'Unknown', 'Unknown'
         activator_token = ''
         try:
             # get the remaining model information we want from the data_model ("title") in the tuple
             for model in settings.global_var.model_info.items():
                 if model[1][0] == rev[3]:
-                    model_name = model[0]
-                    filename = model[1][1]
+                    display_name = model[0]
+                    model_name = model[1][1]
                     model_hash = model[1][2]
                     if model[1][3]:
                         activator_token = f'\nActivator token - ``{model[1][3]}``'
                     break
 
-            # strip any folders from model filename
-            filename = filename.split('_', 1)[-1]
+            # strip any folders from model name
+            model_name = model_name.split('_', 1)[-1]
 
             # generate the command for copy-pasting, and also add embed fields
             embed = discord.Embed(title="About the image!", description="")
             embed.colour = settings.global_var.embed_color
             embed.add_field(name=f'Prompt', value=f'``{rev[17]}``', inline=False)
-            embed.add_field(name='Data model', value=f'Display name - ``{model_name}``\nModel name - ``{filename}``'
+            embed.add_field(name='Data model', value=f'Display name - ``{display_name}``\nModel name - ``{model_name}``'
                                                      f'\nShorthash - ``{model_hash}``{activator_token}', inline=False)
 
-            copy_command = f'/draw prompt:{rev[17]} data_model:{model_name} steps:{rev[4]} width:{rev[5]} ' \
+            copy_command = f'/draw prompt:{rev[17]} data_model:{display_name} steps:{rev[4]} width:{rev[5]} ' \
                            f'height:{rev[6]} guidance_scale:{rev[7]} sampler:{rev[8]} seed:{rev[9]}'
             if rev[2] != '':
                 copy_command += f' negative_prompt:{rev[2]}'

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -342,24 +342,24 @@ class DrawView(View):
         filename, model_hash = 'Unknown', 'Unknown'
         activator_token = ''
         try:
-            # get the remaining model information we want from the data_model (filename) in the tuple
+            # get the remaining model information we want from the data_model ("title") in the tuple
             for model in settings.global_var.model_info.items():
                 if model[1][0] == rev[3]:
                     model_name = model[0]
-                    filename = rev[3]
+                    filename = model[1][1]
                     model_hash = model[1][2]
                     if model[1][3]:
                         activator_token = f'\nActivator token - ``{model[1][3]}``'
                     break
 
             # strip any folders from model filename
-            filename = filename.split('/', 1)[-1].split('\\', 1)[-1]
+            filename = filename.split('_', 1)[-1]
 
             # generate the command for copy-pasting, and also add embed fields
             embed = discord.Embed(title="About the image!", description="")
             embed.colour = settings.global_var.embed_color
             embed.add_field(name=f'Prompt', value=f'``{rev[17]}``', inline=False)
-            embed.add_field(name='Data model', value=f'Display name - ``{model_name}``\nFilename - ``{filename}``'
+            embed.add_field(name='Data model', value=f'Display name - ``{model_name}``\nModel name - ``{filename}``'
                                                      f'\nShorthash - ``{model_hash}``{activator_token}', inline=False)
 
             copy_command = f'/draw prompt:{rev[17]} data_model:{model_name} steps:{rev[4]} width:{rev[5]} ' \


### PR DESCRIPTION
This PR addresses a change on Web UI that reverts an earlier change
https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/c1928cdd6194928af0f53f70c51d59479b7025e2

While this revert is convenient for the Web UI user, I thought it was needless for API user (which AIYA is)

The API inexplicably is still able to take AIYA's incomplete model title to successfully swap models, so I won't touch it.
However, I will want to adjust information presented to end user back to how it is in this comment
https://github.com/Kilvoctu/aiyabot/pull/88#issuecomment-1383092409
As of the above Web UI commit, now we have some redundant data.

Also I need to clarify wiki again to make sure people are entering correct into into their models.csv