### PR TITLE
rework hypernetworks

### DIFF
--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -41,7 +41,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             style for style in settings.global_var.style_names
         ]
 
-    # and hypernetworks
+    # and hyper networks
     def hyper_autocomplete(self: discord.AutocompleteContext):
         return [
             hyper for hyper in settings.global_var.hyper_names
@@ -227,12 +227,15 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         for model in settings.global_var.model_info.items():
             if model[0] == data_model:
                 model_name = model[0]
-                # go one deeper into nest and grab model full name to send to API
                 data_model = model[1][0]
                 # look at the model for activator token and prepend prompt with it
                 if model[1][3]:
                     prompt = model[1][3] + " " + prompt
                 break
+
+        # if a hyper network is used, append it to the prompt
+        if hypernet != 'None':
+            prompt += f' <hypernet:{hypernet}:1>'
 
         if not settings.global_var.send_model:
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
@@ -386,8 +389,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     "restore_faces": True,
                 }
                 payload.update(facefix_payload)
-            if queue_object.hypernet != 'None':
-                override_settings["sd_hypernetwork"] = queue_object.hypernet
 
             # update payload with override_settings
             override_payload = {
@@ -417,7 +418,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
             # create safe/sanitized filename
             keep_chars = (' ', '.', '_')
-            file_name = "".join(c for c in queue_object.prompt if c.isalnum() or c in keep_chars).rstrip()
+            file_name = "".join(c for c in queue_object.simple_prompt if c.isalnum() or c in keep_chars).rstrip()
 
             # save local copy of image and prepare PIL images
             pil_images = []

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -375,7 +375,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     "enable_hr": True,
                     "hr_upscaler": queue_object.highres_fix,
                     "hr_scale": 1,
-                    "hr_second_pass_steps": queue_object.steps/2,
+                    "hr_second_pass_steps": int(queue_object.steps)/2,
                     "denoising_strength": queue_object.strength
                 }
                 payload.update(highres_payload)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -201,6 +201,9 @@ class DrawModal(Modal):
             # update the prompt again if a valid model change is requested
             if model_found:
                 pen[1] = new_token + pen[17]
+            # if a hypernetwork is added, append it to prompt
+            if pen[18] != 'None':
+                pen[1] += pen[18]
 
             # the updated tuple to send to queue
             prompt_tuple = tuple(pen)
@@ -214,7 +217,7 @@ class DrawModal(Modal):
                 prompt_output += f'\nNew model: ``{new_model}``'
             index_start = 4
             for index, value in enumerate(tuple_names[index_start:], index_start):
-                if 17 <= index <= 18:
+                if index == 17:
                     continue
                 if str(pen[index]) != str(self.input_tuple[index]):
                     prompt_output += f'\nNew {value}: ``{pen[index]}``'
@@ -389,7 +392,7 @@ class DrawView(View):
                 extra_params += f'\nCLIP skip: ``{rev[16]}``'
             if rev[18] != 'None':
                 copy_command += f' hypernet:{rev[18]}'
-                extra_params += f'\nHypernetwork model(hash): ``{rev[18]}``'
+                extra_params += f'\nHypernetwork model: ``{rev[18]}``'
             embed.add_field(name=f'Other parameters', value=extra_params, inline=False)
             embed.add_field(name=f'Command for copying', value=f'``{copy_command}``', inline=False)
 

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -203,7 +203,7 @@ class DrawModal(Modal):
                 pen[1] = new_token + pen[17]
             # if a hypernetwork is added, append it to prompt
             if pen[18] != 'None':
-                pen[1] += pen[18]
+                pen[1] += f' <hypernet:{pen[18]}:1>'
 
             # the updated tuple to send to queue
             prompt_tuple = tuple(pen)


### PR DESCRIPTION
This PR is meant to address https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/40ff6db5325fc34ad4fa35e80cb1e7768d9f7e75, in which hypernetworks and such have been reworked in the Web UI into "extra networks"

-----
**After merging this PR, AIYA will require Web UI minimum commit of `40ff6db` in order to use hypernetworks, as I'll be removing the code for the previous method.**

-----

Anyway, with the mentioned Web UI commit, the process for API has been changed.
Previously hypernets are passed to API through `override_settings` in payload. This is not possible anymore (the settings have been removed).
The intended usage for extra networks is now adding a syntax directly to the prompt. In this case, it's `<hypernet:name:multiplier>`. This was confirmed directly by Automatic1111 himself, and that it should work through API (and I double confirmed it by running a quick test).

In order for this PR to be successful, I want the process for end user to be exactly the same, as well as nothing looking any different. It will still be using /draw, then adding hypernet option when desired.

As a sidenote, more advanced, savvy users will now have the option to manually add in the extra networks into the prompt, too. I will want to add this to wiki and /tips command at some point.

This PR will close #92 