### PR TITLE
Rework (remove) per-server defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,8 @@ To generate an image from text, use the /draw command and include your prompt as
 
 #### Bonus features
 
-- /settings command - set per-server defaults for the following (_see Notes!_):
-  - negative prompts
-  - model/checkpoint
-  - sampling steps / max steps
-  - width/height
-  - CFG scale
-  - sampling method
-  - high-res fix
-  - CLIP skip
-  - hypernetworks
-  - batch count / max batch count
+- /settings command - set per-channel defaults for supported options (_see Notes!_):
+  - also can set maximum steps limit and max batch count limit
   - refresh (update AIYA's options with any changes from Web UI)
 - /identify command - create a caption for your image.
 - /stats command - shows how many /draw commands have been used.

--- a/aiya.py
+++ b/aiya.py
@@ -39,8 +39,8 @@ async def stats(ctx):
 async def on_ready():
     self.logger.info(f'Logged in as {self.user.name} ({self.user.id})')
     await self.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name='drawing tutorials.'))
-    # because guilds are only known when on_ready, run files check for guilds
-    settings.guilds_check(self)
+    for guild in self.guilds:
+        print(f"I'm active in {guild.id} a.k.a {guild}!")
 
 
 # fallback feature to delete generations if aiya has been restarted
@@ -63,8 +63,7 @@ async def on_raw_reaction_add(ctx):
 
 @self.event
 async def on_guild_join(guild):
-    print(f'Wow, I joined {guild.name}! Refreshing settings.')
-    settings.guilds_check(self)
+    print(f'Wow, I joined {guild.name}!.')
 
 
 async def shutdown(bot):

--- a/aiya.py
+++ b/aiya.py
@@ -63,7 +63,7 @@ async def on_raw_reaction_add(ctx):
 
 @self.event
 async def on_guild_join(guild):
-    print(f'Wow, I joined {guild.name}!.')
+    print(f'Wow, I joined {guild.name}!')
 
 
 async def shutdown(bot):

--- a/core/settings.py
+++ b/core/settings.py
@@ -80,13 +80,13 @@ def check(channel_id):
     except FileNotFoundError:
         build(str(channel_id))
         print(f'This is a new channel!? Creating default settings file for this channel ({channel_id}).')
-        # if models.csv has the blank "Default" data, update guild settings
+        # if models.csv has the blank "Default" data, update default settings
         with open('resources/models.csv', 'r', encoding='utf-8') as f:
             reader = csv.DictReader(f, delimiter='|')
             for row in reader:
                 if row['display_name'] == 'Default' and row['model_full_name'] == '':
                     update(str(channel_id), 'data_model', '')
-                    print('I see models.csv is on defaults. Updating guild model settings to default.')
+                    print('I see models.csv is on defaults. Updating model settings to default.')
 
 
 def build(channel_id):

--- a/core/settings.py
+++ b/core/settings.py
@@ -275,10 +275,9 @@ def populate_global_vars():
     with open('resources/models.csv', encoding='utf-8') as csv_file:
         model_data = list(csv.reader(csv_file, delimiter='|'))
         for row in model_data[1:]:
-            row_convert = row[1].replace('\\', '_').replace('/', '_')
             for model in r.json():
-                if row_convert == model['title'] or row_convert == model['model_name'] \
-                        or row[1] == model['title'] or row[1] == model['model_name']:
+                if row[1].split('\\')[-1] == model['filename'].split('\\')[-1] \
+                        or row[1].replace('\\', '_').replace('/', '_') == model['model_name']:
                     global_var.model_info[row[0]] = model['title'], model['model_name'], model['hash'], row[2]
                     break
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -15,10 +15,10 @@ path = 'resources/'.format(dir_path)
 template = {
     "negative_prompt": "",
     "data_model": "",
-    "default_steps": 30,
+    "steps": 30,
     "max_steps": 50,
-    "default_width": 512,
-    "default_height": 512,
+    "width": 512,
+    "height": 512,
     "guidance_scale": "7.0",
     "sampler": "Euler a",
     "style": "None",
@@ -26,7 +26,8 @@ template = {
     "highres_fix": 'Disabled',
     "clip_skip": 1,
     "hypernet": "None",
-    "default_count": 1,
+    "strength": "0.75",
+    "count": 1,
     "max_count": 1
 }
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -21,6 +21,8 @@ template = {
     "default_height": 512,
     "guidance_scale": "7.0",
     "sampler": "Euler a",
+    "style": "None",
+    "facefix": "None",
     "highres_fix": 'Disabled',
     "clip_skip": 1,
     "hypernet": "None",

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -133,6 +133,11 @@ class SettingsCog(commands.Cog):
         autocomplete=discord.utils.basic_autocomplete(hyper_autocomplete),
     )
     @option(
+        'strength',
+        str,
+        description='Set default strength (for init_img) for the channel (0.0 to 1.0).'
+    )
+    @option(
         'count',
         int,
         description='Set default count for the channel',
@@ -167,6 +172,7 @@ class SettingsCog(commands.Cog):
                                highres_fix: Optional[str] = None,
                                clip_skip: Optional[int] = 0,
                                hypernet: Optional[str] = None,
+                               strength: Optional[str] = None,
                                count: Optional[int] = None,
                                max_count: Optional[int] = None,
                                refresh: Optional[bool] = False):
@@ -217,18 +223,18 @@ class SettingsCog(commands.Cog):
             settings.update(channel, 'max_steps', max_steps)
             new += f'\nMax steps: ``{max_steps}``'
             # automatically lower default steps if max steps goes below it
-            if max_steps < reviewer['default_steps']:
-                settings.update(channel, 'default_steps', max_steps)
+            if max_steps < reviewer['steps']:
+                settings.update(channel, 'steps', max_steps)
                 new += f'\nDefault steps is too high! Lowering to ``{max_steps}``.'
             set_new = True
 
         if width != 1:
-            settings.update(channel, 'default_width', width)
+            settings.update(channel, 'width', width)
             new += f'\nWidth: ``"{width}"``'
             set_new = True
 
         if height != 1:
-            settings.update(channel, 'default_height', height)
+            settings.update(channel, 'height', height)
             new += f'\nHeight: ``"{height}"``'
             set_new = True
 
@@ -272,12 +278,17 @@ class SettingsCog(commands.Cog):
             new += f'\nHypernet: ``"{hypernet}"``'
             set_new = True
 
+        if strength is not None:
+            settings.update(channel, 'strength', strength)
+            new += f'\nStrength: ``"{strength}"``'
+            set_new = True
+
         if max_count is not None:
             settings.update(channel, 'max_count', max_count)
             new += f'\nMax count: ``{max_count}``'
             # automatically lower default count if max count goes below it
-            if max_count < reviewer['default_count']:
-                settings.update(channel, 'default_count', max_count)
+            if max_count < reviewer['count']:
+                settings.update(channel, 'count', max_count)
                 new += f'\nDefault count is too high! Lowering to ``{max_count}``.'
             set_new = True
 
@@ -287,7 +298,7 @@ class SettingsCog(commands.Cog):
             if steps > reviewer['max_steps']:
                 new += f"\nMax steps is ``{reviewer['max_steps']}``! You can't go beyond it!"
             else:
-                settings.update(channel, 'default_steps', steps)
+                settings.update(channel, 'steps', steps)
                 new += f'\nSteps: ``{steps}``'
             set_new = True
 
@@ -295,7 +306,7 @@ class SettingsCog(commands.Cog):
             if count > reviewer['max_count']:
                 new += f"\nMax count is ``{reviewer['max_count']}``! You can't go beyond it!"
             else:
-                settings.update(channel, 'default_count', count)
+                settings.update(channel, 'count', count)
                 new += f'\nCount: ``{count}``'
             set_new = True
 

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -11,12 +11,20 @@ class SettingsCog(commands.Cog):
         self.bot = bot
 
     # pulls from model_names list and makes some sort of dynamic list to bypass Discord 25 choices limit
+    # these are used also by stablecog /draw command
+    # this also updates list when using /settings "refresh" option
     def model_autocomplete(self: discord.AutocompleteContext):
         return [
             model for model in settings.global_var.model_info
         ]
-    # and for hypernetworks
 
+    # and for styles
+    def style_autocomplete(self: discord.AutocompleteContext):
+        return [
+            style for style in settings.global_var.style_names
+        ]
+
+    # and hyper networks
     def hyper_autocomplete(self: discord.AutocompleteContext):
         return [
             hyper for hyper in settings.global_var.hyper_names
@@ -28,17 +36,17 @@ class SettingsCog(commands.Cog):
             hires for hires in settings.global_var.hires_upscaler_names
         ]
 
-    @commands.slash_command(name='settings', description='Review and change server defaults', guild_only=True)
+    @commands.slash_command(name='settings', description='Review and change channel defaults', guild_only=True)
     @option(
         'current_settings',
         bool,
-        description='Show the current defaults for the server.',
+        description='Show the current defaults for the channel.',
         required=False,
     )
     @option(
         'n_prompt',
         str,
-        description='Set default negative prompt for the server',
+        description='Set default negative prompt for the channel',
         required=False,
     )
     @option(
@@ -51,76 +59,90 @@ class SettingsCog(commands.Cog):
     @option(
         'steps',
         int,
-        description='Set default amount of steps for the server',
+        description='Set default amount of steps for the channel',
         min_value=1,
         required=False,
     )
     @option(
         'max_steps',
         int,
-        description='Set maximum steps for the server',
+        description='Set maximum steps for the channel',
         min_value=1,
         required=False,
     )
     @option(
         'width',
         int,
-        description='Set default width for the server',
+        description='Set default width for the channel',
         required=False,
         choices=[x for x in range(192, 1088, 64)]
     )
     @option(
         'height',
         int,
-        description='Set default height for the server',
+        description='Set default height for the channel',
         required=False,
         choices=[x for x in range(192, 1088, 64)]
     )
     @option(
         'guidance_scale',
         str,
-        description='Set default Classifier-Free Guidance scale for the server.',
+        description='Set default Classifier-Free Guidance scale for the channel.',
         required=False,
     )
     @option(
         'sampler',
         str,
-        description='Set default sampler for the server',
+        description='Set default sampler for the channel',
         required=False,
         choices=settings.global_var.sampler_names,
     )
     @option(
+        'style',
+        str,
+        description='Apply a predefined style to the generation.',
+        required=False,
+        autocomplete=discord.utils.basic_autocomplete(style_autocomplete),
+    )
+    @option(
+        'facefix',
+        str,
+        description='Tries to improve faces in images.',
+        required=False,
+        choices=settings.global_var.facefix_models,
+    )
+    @option(
         'highres_fix',
         str,
-        description='Set default highres fix model for the server',
+        description='Set default highres fix model for the channel',
         required=False,
         autocomplete=discord.utils.basic_autocomplete(hires_autocomplete),
     )
     @option(
         'clip_skip',
         int,
-        description='Set default CLIP skip for the server',
+        description='Set default CLIP skip for the channel',
         required=False,
         choices=[x for x in range(1, 13, 1)]
     )
     @option(
         'hypernet',
         str,
-        description='Set default hypernetwork model for the server',
+        description='Set default hypernetwork model for the channel',
         required=False,
         autocomplete=discord.utils.basic_autocomplete(hyper_autocomplete),
     )
     @option(
         'count',
         int,
-        description='Set default count for the server',
+        description='Set default count for the channel',
         min_value=1,
         required=False,
     )
     @option(
         'max_count',
         int,
-        description='Set maximum count for the server',
+        description='Set maximum count for the channel',
         min_value=1,
         required=False,
     )
@@ -139,7 +161,9 @@ class SettingsCog(commands.Cog):
                                width: Optional[int] = 1,
                                height: Optional[int] = 1,
                                guidance_scale: Optional[str] = None,
-                               sampler: Optional[str] = 'unset',
+                               sampler: Optional[str] = None,
+                               style: Optional[str] = None,
+                               facefix: Optional[str] = None,
                                highres_fix: Optional[str] = None,
                                clip_skip: Optional[int] = 0,
                                hypernet: Optional[str] = None,
@@ -218,9 +242,19 @@ class SettingsCog(commands.Cog):
                 new += f'\nHad trouble setting Guidance Scale! Setting to default of `7.0`.'
             set_new = True
 
-        if sampler != 'unset':
+        if sampler is not None:
             settings.update(channel, 'sampler', sampler)
             new += f'\nSampler: ``"{sampler}"``'
+            set_new = True
+
+        if style is not None:
+            settings.update(channel, 'style', style)
+            new += f'\nStyle: ``"{style}"``'
+            set_new = True
+
+        if facefix is not None:
+            settings.update(channel, 'facefix', facefix)
+            new += f'\nFacefix: ``"{facefix}"``'
             set_new = True
 
         if highres_fix is not None:

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -159,18 +159,17 @@ class SettingsCog(commands.Cog):
     )
     async def settings_handler(self, ctx,
                                current_settings: Optional[bool] = True,
-                               n_prompt: Optional[str] = 'unset',
+                               n_prompt: Optional[str] = None,
                                data_model: Optional[str] = None,
-                               steps: Optional[int] = 1,
+                               steps: Optional[int] = None,
                                max_steps: Optional[int] = 1,
-                               width: Optional[int] = 1,
-                               height: Optional[int] = 1,
+                               width: Optional[int] = None, height: Optional[int] = None,
                                guidance_scale: Optional[str] = None,
                                sampler: Optional[str] = None,
                                style: Optional[str] = None,
                                facefix: Optional[str] = None,
                                highres_fix: Optional[str] = None,
-                               clip_skip: Optional[int] = 0,
+                               clip_skip: Optional[int] = None,
                                hypernet: Optional[str] = None,
                                strength: Optional[str] = None,
                                count: Optional[int] = None,
@@ -209,7 +208,7 @@ class SettingsCog(commands.Cog):
             embed.add_field(name=f'Refreshed!', value=f'Updated global lists', inline=False)
 
         # run through each command and update the defaults user selects
-        if n_prompt != 'unset':
+        if n_prompt is not None:
             settings.update(channel, 'negative_prompt', n_prompt)
             new += f'\nNegative prompts: ``"{n_prompt}"``'
             set_new = True
@@ -228,12 +227,12 @@ class SettingsCog(commands.Cog):
                 new += f'\nDefault steps is too high! Lowering to ``{max_steps}``.'
             set_new = True
 
-        if width != 1:
+        if width is not None:
             settings.update(channel, 'width', width)
             new += f'\nWidth: ``"{width}"``'
             set_new = True
 
-        if height != 1:
+        if height is not None:
             settings.update(channel, 'height', height)
             new += f'\nHeight: ``"{height}"``'
             set_new = True
@@ -268,7 +267,7 @@ class SettingsCog(commands.Cog):
             new += f'\nhighres_fix: ``"{highres_fix}"``'
             set_new = True
 
-        if clip_skip != 0:
+        if clip_skip is not None:
             settings.update(channel, 'clip_skip', clip_skip)
             new += f'\nCLIP skip: ``{clip_skip}``'
             set_new = True
@@ -294,7 +293,7 @@ class SettingsCog(commands.Cog):
 
         # review settings again in case user is trying to set steps/counts and max steps/counts simultaneously
         reviewer = settings.read(channel)
-        if steps != 1:
+        if steps is not None:
             if steps > reviewer['max_steps']:
                 new += f"\nMax steps is ``{reviewer['max_steps']}``! You can't go beyond it!"
             else:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -160,7 +160,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             highres_fix: Optional[str] = None,
                             clip_skip: Optional[int] = 0,
                             hypernet: Optional[str] = None,
-                            strength: Optional[str] = '0.75',
+                            strength: Optional[str] = None,
                             init_image: Optional[discord.Attachment] = None,
                             init_url: Optional[str],
                             count: Optional[int] = None):
@@ -172,11 +172,11 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         if negative_prompt == 'unset':
             negative_prompt = settings.read(channel)['negative_prompt']
         if steps == -1:
-            steps = settings.read(channel)['default_steps']
+            steps = settings.read(channel)['steps']
         if width == 1:
-            width = settings.read(channel)['default_width']
+            width = settings.read(channel)['width']
         if height == 1:
-            height = settings.read(channel)['default_height']
+            height = settings.read(channel)['height']
         if guidance_scale is None:
             guidance_scale = settings.read(channel)['guidance_scale']
         if sampler is None:
@@ -191,8 +191,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             clip_skip = settings.read(channel)['clip_skip']
         if hypernet is None:
             hypernet = settings.read(channel)['hypernet']
+        if strength is None:
+            strength = settings.read(channel)['strength']
         if count is None:
-            count = settings.read(channel)['default_count']
+            count = settings.read(channel)['count']
 
         # if a model is not selected, do nothing
         model_name = 'Default'

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -148,17 +148,17 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         required=False,
     )
     async def dream_handler(self, ctx: discord.ApplicationContext, *,
-                            prompt: str, negative_prompt: str = 'unset',
+                            prompt: str, negative_prompt: str = None,
                             data_model: Optional[str] = None,
-                            steps: Optional[int] = -1,
-                            width: Optional[int] = 1, height: Optional[int] = 1,
+                            steps: Optional[int] = None,
+                            width: Optional[int] = None, height: Optional[int] = None,
                             guidance_scale: Optional[str] = None,
                             sampler: Optional[str] = None,
                             seed: Optional[int] = -1,
                             style: Optional[str] = None,
                             facefix: Optional[str] = None,
                             highres_fix: Optional[str] = None,
-                            clip_skip: Optional[int] = 0,
+                            clip_skip: Optional[int] = None,
                             hypernet: Optional[str] = None,
                             strength: Optional[str] = None,
                             init_image: Optional[discord.Attachment] = None,
@@ -169,13 +169,13 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # update defaults with any new defaults from settingscog
         channel = '% s' % ctx.channel.id
         settings.check(channel)
-        if negative_prompt == 'unset':
+        if negative_prompt is None:
             negative_prompt = settings.read(channel)['negative_prompt']
-        if steps == -1:
+        if steps is None:
             steps = settings.read(channel)['steps']
-        if width == 1:
+        if width is None:
             width = settings.read(channel)['width']
-        if height == 1:
+        if height is None:
             height = settings.read(channel)['height']
         if guidance_scale is None:
             guidance_scale = settings.read(channel)['guidance_scale']
@@ -187,7 +187,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             facefix = settings.read(channel)['facefix']
         if highres_fix is None:
             highres_fix = settings.read(channel)['highres_fix']
-        if clip_skip == 0:
+        if clip_skip is None:
             clip_skip = settings.read(channel)['clip_skip']
         if hypernet is None:
             hypernet = settings.read(channel)['hypernet']

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -191,32 +191,33 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
         settings.global_var.send_model = False
         # update defaults with any new defaults from settingscog
-        guild = '% s' % ctx.guild_id
+        channel = '% s' % ctx.channel.id
+        settings.check(channel)
         if negative_prompt == 'unset':
-            negative_prompt = settings.read(guild)['negative_prompt']
+            negative_prompt = settings.read(channel)['negative_prompt']
         if steps == -1:
-            steps = settings.read(guild)['default_steps']
+            steps = settings.read(channel)['default_steps']
         if width == 1:
-            width = settings.read(guild)['default_width']
+            width = settings.read(channel)['default_width']
         if height == 1:
-            height = settings.read(guild)['default_height']
+            height = settings.read(channel)['default_height']
         if guidance_scale is None:
-            guidance_scale = settings.read(guild)['guidance_scale']
+            guidance_scale = settings.read(channel)['guidance_scale']
         if sampler == 'unset':
-            sampler = settings.read(guild)['sampler']
+            sampler = settings.read(channel)['sampler']
         if highres_fix is None:
-            highres_fix = settings.read(guild)['highres_fix']
+            highres_fix = settings.read(channel)['highres_fix']
         if clip_skip == 0:
-            clip_skip = settings.read(guild)['clip_skip']
+            clip_skip = settings.read(channel)['clip_skip']
         if hypernet is None:
-            hypernet = settings.read(guild)['hypernet']
+            hypernet = settings.read(channel)['hypernet']
         if count is None:
-            count = settings.read(guild)['default_count']
+            count = settings.read(channel)['default_count']
 
         # if a model is not selected, do nothing
         model_name = 'Default'
         if data_model is None:
-            data_model = settings.read(guild)['data_model']
+            data_model = settings.read(channel)['data_model']
             if data_model != '':
                 settings.global_var.send_model = True
         else:
@@ -255,8 +256,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # formatting aiya initial reply
         reply_adds = ''
         # lower step value to the highest setting if user goes over max steps
-        if steps > settings.read(guild)['max_steps']:
-            steps = settings.read(guild)['max_steps']
+        if steps > settings.read(channel)['max_steps']:
+            steps = settings.read(channel)['max_steps']
             reply_adds += f'\nExceeded maximum of ``{steps}`` steps! This is the best I can do...'
         if model_name != 'Default':
             reply_adds += f'\nModel: ``{model_name}``'
@@ -277,7 +278,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nStrength: ``{strength}``'
             reply_adds += f'\nURL Init Image: ``{init_image.url}``'
         if count != 1:
-            max_count = settings.read(guild)['max_count']
+            max_count = settings.read(channel)['max_count']
             if count > max_count:
                 count = max_count
                 reply_adds += f'\nExceeded maximum of ``{count}`` images! This is the best I can do...'

--- a/core/tipscog.py
+++ b/core/tipscog.py
@@ -125,10 +125,12 @@ class TipsView(View):
 
         url = 'https://github.com/Kilvoctu/aiyabot'
         url2 = 'https://raw.githubusercontent.com/Kilvoctu/kilvoctu.github.io/master/pics/previewthumb.png'
+        url3 = 'https://github.com/Kilvoctu/aiyabot/wiki#using-aiya'
         embed_about = discord.Embed(title="About me",
                                     description=f"Hi! I'm an open-source Discord bot written in Python.\n"
-                                                f"[My home is here]({url}) if you'd like to check it out!\n"
-                                                f"Feel free to report bugs or leave feedback.")
+                                                f"[My home is here]({url}) if you'd like to check it out,\n"
+                                                f" and my [wiki]({url3}) has some basic info on usage!\n\n"
+                                                f"Feel free to report bugs or leave feedback!")
         embed_about.colour = settings.global_var.embed_color
         embed_about.set_thumbnail(url=url2)
         embed_about.set_footer(text='Have a lovely day!', icon_url=url2)

--- a/core/tipscog.py
+++ b/core/tipscog.py
@@ -129,7 +129,7 @@ class TipsView(View):
         embed_about = discord.Embed(title="About me",
                                     description=f"Hi! I'm an open-source Discord bot written in Python.\n"
                                                 f"[My home is here]({url}) if you'd like to check it out,\n"
-                                                f" and my [wiki]({url3}) has some basic info on usage!\n\n"
+                                                f" and the [wiki]({url3}) has some basic info on usage!\n\n"
                                                 f"Feel free to report bugs or leave feedback!")
         embed_about.colour = settings.global_var.embed_color
         embed_about.set_thumbnail(url=url2)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -124,7 +124,7 @@ class DrawModal(Modal):
                                         inline=False)
 
             if 'steps:' in line:
-                max_steps = settings.read('% s' % pen[0].guild_id)['max_steps']
+                max_steps = settings.read('% s' % pen[0].channel.id)['max_steps']
                 if 0 < int(line.split(':', 1)[1]) <= max_steps:
                     pen[4] = line.split(':', 1)[1]
                 else:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -394,7 +394,7 @@ class DrawView(View):
                 copy_command += f' hypernet:{rev[18]}'
                 extra_params += f'\nHypernetwork model: ``{rev[18]}``'
             embed.add_field(name=f'Other parameters', value=extra_params, inline=False)
-            embed.add_field(name=f'Command for copying', value=f'``{copy_command}``', inline=False)
+            embed.add_field(name=f'Command for copying', value=f'{copy_command}', inline=False)
 
             await interaction.response.send_message(embed=embed, ephemeral=True)
         except Exception as e:


### PR DESCRIPTION
This PR will change the feature for per-server defaults into per-channel defaults.

People who run AIYA on multiple servers are probably quite rare, as it's so impractical. However, it's a lot more reasonable to conclude that hosts who run AIYA in their server can have multiple channels dedicated to different types of art generations.

---

Per-server defaults will be removed, but only because it's completely redundant.

### _**For bot hosts, you need to set your desired defaults again, because server defaults are no longer read.**_ 

To do this, run the /settings command *within the channel* in which you want set your defaults for.   
The /settings output is now ephemeral (invisible to everyone else), so there is no concern about spamming the embed output whenever you review settings.

After you set your desired channel defaults, you can delete the old json files for your servers. AIYA tells you the guild id of each in console log, which corresponds to the json filename.

---

In practice:
Not much should be different for end user. They may notice that there could be different parameters by default across different channels.

For bot hosts, there is the slightly different process, and also the /settings embed provides the channel id for reference.

---

todo:
- testing
- update readme ✅ _done_
- update wiki ✅ _done_
- edit: may as well add the remaining parameters to /settings (Web UI styles, facefix, denoise strength)✅ _done_