### PR TITLE
Adjust initial reply

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -123,6 +123,8 @@ def prompt_mod(prompt, negative_prompt):
             if y in prompt.lower():
                 prompt = prompt.replace(y, "")
         prompt = ' '.join(prompt.split())
+        if prompt == '':
+            prompt = ' '
         for z in global_var.negative_prompt_prefix:
             z = str(z.lower())
             if z in negative_prompt.lower():

--- a/core/settings.py
+++ b/core/settings.py
@@ -66,6 +66,8 @@ max_size = 1024
 prompt_ban_list = []
 # These words will be automatically removed from the prompt.
 prompt_ignore_list = []
+# Choose whether or not ignored words are displayed to user.
+display_ignored_words = "False"
 # These words will be added to the beginning of the negative prompt.
 negative_prompt_prefix = []
 """
@@ -99,6 +101,7 @@ class GlobalVar:
     queue_limit = 1
     prompt_ban_list = []
     prompt_ignore_list = []
+    display_ignored_words = "False"
     negative_prompt_prefix = []
 
 
@@ -119,6 +122,7 @@ def prompt_mod(prompt, negative_prompt):
             y = str(y.lower())
             if y in prompt.lower():
                 prompt = prompt.replace(y, "")
+        prompt = ' '.join(prompt.split())
         for z in global_var.negative_prompt_prefix:
             z = str(z.lower())
             if z in negative_prompt.lower():
@@ -339,6 +343,7 @@ def populate_global_vars():
     global_var.queue_limit = config['queue_limit']
     global_var.prompt_ban_list = [x for x in config['prompt_ban_list']]
     global_var.prompt_ignore_list = [x for x in config['prompt_ignore_list']]
+    global_var.display_ignored_words = config['display_ignored_words']
     global_var.negative_prompt_prefix = [x for x in config['negative_prompt_prefix']]
     # slash command doesn't update this dynamically. Changes to size need a restart.
     global_var.size_range = range(192, config['max_size']+64, 64)

--- a/core/settings.py
+++ b/core/settings.py
@@ -205,7 +205,7 @@ def startup_check():
 
     # update the config if any new keys were added
     if not tomlkit.loads(default_config).keys() == config.keys():
-        print('Configuration file is missing keys! Updating the file.')
+        print('Configuration file keys mismatch! Updating the file.')
         temp_config = {}
         for k, v in config.items():
             temp_config[k] = v

--- a/core/settings.py
+++ b/core/settings.py
@@ -106,6 +106,7 @@ global_var = GlobalVar()
 
 
 def prompt_mod(prompt, negative_prompt):
+    clean_negative_prompt = negative_prompt
     # if any banned words are in prompt, return immediately
     if global_var.prompt_ban_list:
         for x in global_var.prompt_ban_list:
@@ -124,7 +125,7 @@ def prompt_mod(prompt, negative_prompt):
                 pass
             else:
                 negative_prompt = f"{z} {negative_prompt}"
-        return "Mod", prompt, negative_prompt.strip()
+        return "Mod", prompt, negative_prompt.strip(), clean_negative_prompt
     return "None"
 
 

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -230,9 +230,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 return
             if mod_results[0] == "Mod":
                 if settings.global_var.display_ignored_words == "False":
-                    simple_prompt = mod_results[1].strip()
-                    if simple_prompt == '':
-                        simple_prompt = ' '
+                    simple_prompt = mod_results[1]
                 prompt = mod_results[1]
                 negative_prompt = mod_results[2]
                 clean_negative = mod_results[3]

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -229,6 +229,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 await ctx.respond(f"I'm not allowed to draw the word {mod_results[1]}!", ephemeral=True)
                 return
             if mod_results[0] == "Mod":
+                if settings.global_var.display_ignored_words == "False":
+                    simple_prompt = mod_results[1].strip()
+                    if simple_prompt == '':
+                        simple_prompt = ' '
                 prompt = mod_results[1]
                 negative_prompt = mod_results[2]
                 clean_negative = mod_results[3]

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -260,18 +260,18 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nExceeded maximum of ``{steps}`` steps! This is the best I can do...'
         if model_name != 'Default':
             reply_adds += f'\nModel: ``{model_name}``'
-        if negative_prompt != '':
+        if negative_prompt != settings.read(channel)['negative_prompt']:
             reply_adds += f'\nNegative Prompt: ``{negative_prompt}``'
         if (width != 512) or (height != 512):
             reply_adds += f'\nSize: ``{width}``x``{height}``'
-        if guidance_scale != '7.0':
+        if guidance_scale != settings.read(channel)['guidance_scale']:
             try:
                 float(guidance_scale)
                 reply_adds += f'\nGuidance Scale: ``{guidance_scale}``'
             except(Exception,):
                 reply_adds += f"\nGuidance Scale can't be ``{guidance_scale}``! Setting to default of `7.0`."
                 guidance_scale = 7.0
-        if sampler != 'Euler a':
+        if sampler != settings.read(channel)['sampler']:
             reply_adds += f'\nSampler: ``{sampler}``'
         if init_image:
             reply_adds += f'\nStrength: ``{strength}``'
@@ -282,15 +282,15 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 count = max_count
                 reply_adds += f'\nExceeded maximum of ``{count}`` images! This is the best I can do...'
             reply_adds += f'\nCount: ``{count}``'
-        if style != 'None':
+        if style != settings.read(channel)['style']:
             reply_adds += f'\nStyle: ``{style}``'
-        if hypernet != 'None':
+        if hypernet != settings.read(channel)['hypernet']:
             reply_adds += f'\nHypernet: ``{hypernet}``'
-        if lora != 'None':
+        if lora != settings.read(channel)['lora']:
             reply_adds += f'\nLoRA: ``{lora}``'
-        if facefix != 'None':
+        if facefix != settings.read(channel)['facefix']:
             reply_adds += f'\nFace restoration: ``{facefix}``'
-        if clip_skip != 1:
+        if clip_skip != settings.read(channel)['clip_skip']:
             reply_adds += f'\nCLIP skip: ``{clip_skip}``'
 
         # set up tuple of parameters to pass into the Discord view

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -258,6 +258,9 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
         # formatting aiya initial reply
         reply_adds = ''
+        if (width != 512) or (height != 512):
+            reply_adds += f' - Size: ``{width}``x``{height}``'
+        reply_adds += f' - Seed: ``{seed}``'
         # lower step value to the highest setting if user goes over max steps
         if steps > settings.read(channel)['max_steps']:
             steps = settings.read(channel)['max_steps']
@@ -266,8 +269,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nModel: ``{model_name}``'
         if clean_negative != settings.read(channel)['negative_prompt']:
             reply_adds += f'\nNegative Prompt: ``{clean_negative}``'
-        if (width != 512) or (height != 512):
-            reply_adds += f'\nSize: ``{width}``x``{height}``'
         if guidance_scale != settings.read(channel)['guidance_scale']:
             try:
                 float(guidance_scale)
@@ -317,11 +318,11 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             else:
                 queuehandler.GlobalQueue.queue.append(queuehandler.DrawObject(self, *input_tuple, view))
                 await ctx.send_response(
-                    f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{reply_adds}')
+                    f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{simple_prompt}``\nSteps: ``{steps}``{reply_adds}')
         else:
             await queuehandler.process_dream(self, queuehandler.DrawObject(self, *input_tuple, view))
             await ctx.send_response(
-                f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{simple_prompt}``\nSteps: ``{steps}`` - Seed: ``{seed}``{reply_adds}')
+                f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{simple_prompt}``\nSteps: ``{steps}``{reply_adds}')
 
     # the function to queue Discord posts
     def post(self, event_loop: AbstractEventLoop, post_queue_object: queuehandler.PostObject):

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -222,6 +222,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 break
 
         # run through mod function if any moderation values are set in config
+        clean_negative = ''
         if settings.global_var.prompt_ban_list or settings.global_var.prompt_ignore_list or settings.global_var.negative_prompt_prefix:
             mod_results = settings.prompt_mod(simple_prompt, negative_prompt)
             if mod_results[0] == "Stop":
@@ -230,6 +231,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if mod_results[0] == "Mod":
                 prompt = mod_results[1]
                 negative_prompt = mod_results[2]
+                clean_negative = mod_results[3]
 
         # if a hypernet or lora is used, append it to the prompt
         if hypernet != 'None':
@@ -260,8 +262,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nExceeded maximum of ``{steps}`` steps! This is the best I can do...'
         if model_name != 'Default':
             reply_adds += f'\nModel: ``{model_name}``'
-        if negative_prompt != settings.read(channel)['negative_prompt']:
-            reply_adds += f'\nNegative Prompt: ``{negative_prompt}``'
+        if clean_negative != settings.read(channel)['negative_prompt']:
+            reply_adds += f'\nNegative Prompt: ``{clean_negative}``'
         if (width != 512) or (height != 512):
             reply_adds += f'\nSize: ``{width}``x``{height}``'
         if guidance_scale != settings.read(channel)['guidance_scale']:


### PR DESCRIPTION
This PR will change when stuff is displayed in AIYA's initial reply.

Currently, most parameters will be shown if they're not set to `None`, or an arbitrary default that I hardcoded. So this screenshot for example:
![image](https://user-images.githubusercontent.com/2993060/219974865-c2c1a50e-ce83-4307-aeed-ab87bb9d318d.png)
`Sampler` is displayed because it's not arbitrary default of `Euler A`  
`Style` is displayed because it's not `None`

Instead of this behavior, I prefer the parameters to be displayed if they aren't the channel defaults or otherwise pre-filled by AIYA. In other words, show what's changed only if the user changes it. This helps for when channel defaults have tons of parameters set (including huge negative prompt); makes it look less unsightly.  

The exceptions is steps and seed is always shown. Model, I want it to always show if it's not `Default`. Size, I think too, nice to see what you're getting if it's not 512x512.