### PR TITLE
add docker build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
+version: 2
+updates:
+  # Update Python libraries
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of requirements file
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Build and release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - uses: brpaz/hadolint-action@v1.5.0
+        with:
+          dockerfile: ./dockerfile
+
+  docker:
+    name: Docker Build and Push
+    runs-on: ubuntu-latest
+    needs: [lint]
+    permissions:
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry # https://github.com/marketplace/actions/docker-login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker # https://github.com/marketplace/actions/docker-metadata-action
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}},priority=1100
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push # https://github.com/marketplace/actions/build-and-push-docker-images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfile
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ The docker image supports additional configuration by adding environment variabl
 docker run --name aiyabot --network=host --restart=always -e TOKEN=your_token_here -e TZ=America/New_York -v ./aiyabot/outputs:/app/outputs -v ./aiyabot/resources:/app/resources -d ghcr.io/kilvoctu/aiyabot:latest
 ```
 
+Note the following environment variables work with the docker image:
+
+- `TOKEN` - **[Required]** Discord bot token.
+- `URL` - URL of the Web UI API. Defaults to `http://localhost:7860`.
+- `TZ` - Timezone for the container in the format `America/New_York`. Defaults to `America/New_York`
+- `APIUSER` - API username if required for your Web UI instance.
+- `APIPASS` - API password if required for your Web UI instance.
+- `USER` - Username if required for your Web UI instance.
+- `PASS` - Password if required for your Web UI instance.
+
 ### Docker compose
 
 - Clone the repo and refer to the `docker-compose.yml` file in the `deploy` directory.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ TOKEN = put your bot token here
 ```
 - Run AIYA by running launch.bat (or launch.sh for Linux)
 
+## Deploy with Docker
+
+AIYA can be deployed using Docker.
+
+The docker image supports additional configuration by adding environment variables or config file updates detailed in the [wiki](https://github.com/Kilvoctu/aiyabot/wiki/Configuration).
+
+### Docker run
+
+```bash
+docker run --name aiyabot --network=host --restart=always -e TOKEN=your_token_here -e TZ=America/New_York -v ./aiyabot/outputs:/app/outputs -v ./aiyabot/resources:/app/resources -d ghcr.io/kilvoctu/aiyabot:latest
+```
+
+### Docker compose
+
+- Clone the repo and refer to the `docker-compose.yml` file in the `deploy` directory.
+- Rename the `/deploy/.env.example` file to `.env` and update the `TOKEN` variable with your bot token (and any other configuration as desired).
+- Run `docker-compose up -d` to start the bot.
+
 ## Notes
 
 - [See wiki for notes on additional configuration.](https://github.com/Kilvoctu/aiyabot/wiki/Configuration)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,16 @@
+# Token for your discord app. You can get it from https://discordapp.com/developers/applications/me
+TOKEN=
+# Allows you to set a custom URL, including port. The default is "http://127.0.0.1:7860".
+URL=http://127.0.0.1:7860
+# Your timezone in the format of "America/New_York". The default is "America/New_York".
+TZ=America/New_York
+# Your username if you are using --api-auth
+APIUSER=
+# Your password if you are using --api-auth
+APIPASS=
+# Allows you to set a custom folder to save images. The default is "/app/outputs".
+DIR=/app/outputs
+# Your username if you are using --share and --gradio-auth.
+USER=
+# Your password if you are using --share and --gradio-auth.
+PASS=

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,9 +2,6 @@ version: '3'
 
 services:
   aiyabot:
-    build:
-      context: ..
-      dockerfile: dockerfile
     image: ghcr.io/kilvoctu/aiyabot:latest
     environment:
       TOKEN: "${TOKEN}"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  aiyabot:
+    build:
+      context: ..
+      dockerfile: dockerfile
+    image: ghcr.io/kilvoctu/aiyabot:latest
+    environment:
+      TOKEN: "${TOKEN}"
+      TZ: "${TZ}"
+      URL: "${URL}"
+      APIUSER: "${APIUSER}"
+      APIPASS: "${APIPASS}"
+      DIR: "${DIR}"
+      USER: "${USER}"
+      PASS: "${PASS}"
+    container_name: aiyabot
+    restart: always
+    volumes:
+      - ../outputs:/app/outputs
+      - ../resources:/app/resources
+    network_mode: host

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eou pipefail
+
+# Copy the default resource and outputs files if they don't exist.
+cp -n "/default/resources/messages.csv" "/app/resources/messages.csv"
+cp -n "/default/outputs/.keep" "/app/outputs/.keep"
+
+# Start the app.
+python aiya.py

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.10
+
+ENV TOKEN="" \
+	URL="http://127.0.0.1:7860" \
+	TZ="America/New_York" \
+	APIUSER="" \
+	APIPASS="" \
+	USER="" \
+	PASS=""
+
+WORKDIR /app
+
+# Install dependencies
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Pull in the source code
+COPY ./resources /default/resources
+COPY ./outputs /default/outputs
+COPY . /app
+
+# Run the bot
+ENTRYPOINT [ "/app/docker-entrypoint.sh" ]


### PR DESCRIPTION
This PR will add:
* GitHub dependabot scanning of pip packages, actions steps and the docker file steps.
* A docker container spec for creating a package containing the bot. This will be pushed to the github packages attached to the repo.
* A github actions workflow that will build the docker container and update the published version on pushes to the main branch. This workflow will also perform a flake8 lint of the python files on push/PR.