### PR TITLE
Change option "count" to "batch"

### DIFF
--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -5,7 +5,7 @@ from threading import Thread
 # the queue object for txt2image and img2img
 class DrawObject:
     def __init__(self, cog, ctx, simple_prompt, prompt, negative_prompt, data_model, steps, width, height,
-                 guidance_scale, sampler, seed, strength, init_image, batch_count, style, facefix, highres_fix,
+                 guidance_scale, sampler, seed, strength, init_image, batch, style, facefix, highres_fix,
                  clip_skip, hypernet, lora, view):
         self.cog = cog
         self.ctx = ctx
@@ -21,7 +21,7 @@ class DrawObject:
         self.seed = seed
         self.strength = strength
         self.init_image = init_image
-        self.batch_count = batch_count
+        self.batch = batch
         self.style = style
         self.facefix = facefix
         self.highres_fix = highres_fix

--- a/core/settings.py
+++ b/core/settings.py
@@ -30,8 +30,8 @@ template = {
     "hypernet": "None",
     "lora": "None",
     "strength": "0.75",
-    "count": 1,
-    "max_count": 1,
+    "batch": "1,1",
+    "max_batch": "1,1",
     "upscaler_1": "ESRGAN_4x"
 }
 
@@ -111,6 +111,27 @@ class GlobalVar:
 global_var = GlobalVar()
 
 
+def batch_format(batch_string):
+    format_batch_string = batch_string.replace(".", ",").split(",")
+    values_given = len(format_batch_string)
+    if values_given < 2:
+        format_batch_string.append('1')
+    # try ensure each value is an integer of at least 1
+    try:
+        count = int(format_batch_string[0])
+        if count < 1:
+            count = 1
+    except(Exception,):
+        count = 1
+    try:
+        size = int(format_batch_string[1])
+        if size < 1:
+            size = 1
+    except(Exception,):
+        size = 1
+    return count, size, values_given
+
+
 def prompt_mod(prompt, negative_prompt):
     clean_negative_prompt = negative_prompt
     # if any banned words are in prompt, return immediately
@@ -176,6 +197,17 @@ def read(channel_id):
     with open(path + channel_id + '.json', 'r') as configfile:
         settings = dict(template)
         settings.update(json.load(configfile))
+
+        # update deprecated 'count' to 'batch'
+        if 'count' in settings or 'max_count' in settings:
+            try:
+                settings['batch'] = settings.pop('count')
+                settings['max_batch'] = settings.pop('max_count')
+            except(Exception,):
+                pass
+            with open(path + channel_id + '.json', 'w') as configfile2:
+                json.dump(settings, configfile2, indent=1)
+
     return settings
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -116,7 +116,7 @@ def batch_format(batch_string):
     values_given = len(format_batch_string)
     if values_given < 2:
         format_batch_string.append('1')
-    # try ensure each value is an integer of at least 1
+    # try to ensure each value is an integer of at least 1
     try:
         count = int(format_batch_string[0])
         if count < 1:
@@ -161,10 +161,10 @@ def prompt_mod(prompt, negative_prompt):
 
 def stats_count(number):
     with open(f'{path}stats.txt', 'r') as f:
-        data = list(map(int, f.readlines()))
+        data = list(map(float, f.readlines()))
     data[0] += number
     with open(f'{path}stats.txt', 'w') as f:
-        f.write('\n'.join(str(x) for x in data))
+        f.write('\n'.join(str(int(x)) for x in data))
 
 
 def messages():

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -301,6 +301,14 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if batch[2] == 1:
                 # if over the limits, cut the number in half and let AIYA scale down
                 total = max_batch[0] * max_batch[1]
+
+                # add hard limit of 10 images until I can figure how to bypass this discord limit - single value edition
+                if batch[0] > 10:
+                    batch[0] = 10
+                    if total > 10:
+                        total = 10
+                    reply_adds += f"\nI'm currently limited to a max of 10 drawings per post..."
+
                 if batch[0] > total:
                     batch[0] = math.ceil(batch[0] / 2)
                     batch[1] = math.ceil(batch[0] / 2)
@@ -311,7 +319,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     new_total = difference * multiple
                     requested = batch[0]
                     batch[0], batch[1] = difference, multiple
-                    if new_total != total:
+                    if requested % difference != 0:
                         reply_adds += f"\nI can't draw exactly ``{requested}`` pictures! Settling for ``{new_total}``."
             # check batch values against the maximum limits
             if batch[0] > max_batch[0]:
@@ -320,6 +328,16 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             if batch[1] > max_batch[1]:
                 reply_adds += f"\nThe max batch size I'm allowed here is ``{max_batch[1]}``!"
                 batch[1] = max_batch[1]
+
+            # add hard limit of 10 images until I can figure how to bypass this discord limit - multi value edition
+            if batch[0] * batch[1] > 10:
+                while batch[0] * batch[1] > 10:
+                    if batch[0] != 1:
+                        batch[0] -= 1
+                    if batch[1] != 1:
+                        batch[1] -= 1
+                reply_adds += f"\nI'm currently limited to a max of 10 drawings per post..."
+
             reply_adds += f'\nBatch count: ``{batch[0]}`` - Batch size: ``{batch[1]}``'
         if style != settings.read(channel)['style']:
             reply_adds += f'\nStyle: ``{style}``'

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -427,8 +427,10 @@ class DrawView(View):
             if rev[12]:
                 # not interested in adding embed fields for strength and init_image
                 copy_command += f' strength:{rev[11]} init_url:{rev[12].url}'
-            if rev[13] != 1:
-                copy_command += f' count:{rev[13]}'
+            if rev[13][0] != 1 or rev[13][1] != 1:
+                bat_string = ','.join(str(x) for x in rev[13])
+                bat_copy = settings.batch_format(bat_string)
+                copy_command += f' batch:{bat_copy[0]},{bat_copy[1]}'
             if rev[14] != 'None':
                 copy_command += f' style:{rev[14]}'
                 extra_params += f'\nStyle preset: ``{rev[14]}``'

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -30,7 +30,7 @@ input_tuple[0] = ctx
 [19] = lora
 '''
 tuple_names = ['ctx', 'simple_prompt', 'prompt', 'negative_prompt', 'data_model', 'steps', 'width', 'height',
-               'guidance_scale', 'sampler', 'seed', 'strength', 'init_image', 'batch_count', 'style', 'facefix',
+               'guidance_scale', 'sampler', 'seed', 'strength', 'init_image', 'batch', 'style', 'facefix',
                'highres_fix', 'clip_skip', 'hypernet', 'lora']
 
 


### PR DESCRIPTION
This PR changes the behavior of the /draw command option **count**. It also will rename it to **batch**.

Closes #113

---

**batch** can take up to two values, delimited by `,` or `.`. It will parse these values into the batch count and batch size.  

*Example:*
Entering `2,4` for **batch** will send batch count=`2` and batch size=`4` to the Web UI

Sample image
![image](https://user-images.githubusercontent.com/2993060/220802495-fd2db297-ebb9-4fd5-bf24-b3bd9f69b302.png)

![image](https://user-images.githubusercontent.com/2993060/220803182-7147b44a-49b7-4e91-b8a1-5e393ade4ba5.png)
*let's not concern ourselves with how long this took my PC*

---

If entering only one value, AIYA will try to generate that amount of images as allowed by the channel restrictions (prioritizing batch size).  

*Example 1:*
Let's say the channel restriction is `5,5` (batch count=`5`, batch size=`5`)
Entering `20` for **batch** means you want to generate 20 images.  
AIYA will generate 20 images by doing batch count=`4`, batch size=`5`  

*Example 2:*
Same channel restrictions, but you want to generate 5 images.  
AIYA will generate 5 images by doing batch count=`1`, batch size=`5`  

*Example 3:*
Same channel restrictions, but you want to generate 100 images.  
AIYA will generate only 25 images by doing batch count=`5`, batch size=`5`  

---

The /settings command will also be updated to allow channel defaults for **batch**. It does not have the above "one value" logic. If hosts enter just `5`, it'll be batch count=`5`

I know it seems complicated, but in practice the end user is probably going to still be entering one number like usual.

---

done:
- convert instances of "count" to "batch"
- able to set batch in /draw and /settings with new `count,batch` format and Web UI receives it properly
- error handling (errors are set to default of `1` )

todo:
- ~~the "one value" logic described above~~ done(?) ✅
- maybe better error handling
- more testing
- ~~document on wiki~~ [done](https://github.com/Kilvoctu/aiyabot/wiki/draw-command#batch) ✅
edit:
- ~~fix this. Discord limits....~~ in a different pr
![image](https://user-images.githubusercontent.com/2993060/220829908-f204cb2e-6d7f-46fc-b99e-120c43590ea0.png)
- ~~fix "count" display in 📋~~  done ✅
