### PR TITLE
Add executable permissions to docker-entrypoint.sh

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -19,5 +19,7 @@ COPY ./resources /default/resources
 COPY ./outputs /default/outputs
 COPY . /app
 
+RUN chmod +x /app/docker-entrypoint.sh
+
 # Run the bot
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]


### PR DESCRIPTION
I found an issue where the docker-entrypoint.sh script did not have execute rights in the container. 
This should fix it. :)