### PR TITLE
Refactor queue limit

### DIFF
--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -65,28 +65,17 @@ class IdentifyCog(commands.Cog):
 
         view = viewhandler.DeleteView(ctx.author.id)
         # set up the queue if an image was found
-        user_queue = 0
-        user_queue_limit = False
-        for queue_object in queuehandler.GlobalQueue.queue:
-            if queue_object.ctx.author.id == ctx.author.id:
-                user_queue += 1
-                if user_queue >= settings.global_var.queue_limit:
-                    user_queue_limit = True
-                    break
+        user_queue_limit = settings.queue_check(ctx.author)
         if has_image:
             if queuehandler.GlobalQueue.dream_thread.is_alive():
-                if user_queue_limit:
+                if user_queue_limit == "Stop":
                     await ctx.send_response(content=f"Please wait! You're past your queue limit of {settings.global_var.queue_limit}.", ephemeral=True)
                 else:
                     queuehandler.GlobalQueue.queue.append(queuehandler.IdentifyObject(self, ctx, init_image, phrasing, view))
-                    await ctx.send_response(
-                        f"<@{ctx.author.id}>, I'm identifying the image!"
-                        f"\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``", delete_after=45.0)
             else:
                 await queuehandler.process_dream(self, queuehandler.IdentifyObject(self, ctx, init_image, phrasing, view))
-                await ctx.send_response(
-                    f"<@{ctx.author.id}>, I'm identifying the image!"
-                    f"\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``", delete_after=45.0)
+            if user_queue_limit != "Stop":
+                await ctx.send_response(f"<@{ctx.author.id}>, I'm identifying the image!\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``", delete_after=45.0)
 
     # the function to queue Discord posts
     def post(self, event_loop: AbstractEventLoop, post_queue_object: queuehandler.PostObject):

--- a/core/settings.py
+++ b/core/settings.py
@@ -8,10 +8,11 @@ import time
 import tomlkit
 from typing import Optional
 
+from core import queuehandler
+
 self = discord.Bot()
 dir_path = os.path.dirname(os.path.realpath(__file__))
 path = 'resources/'.format(dir_path)
-
 
 # the fallback defaults for AIYA if bot host doesn't set anything
 template = {
@@ -157,6 +158,15 @@ def prompt_mod(prompt, negative_prompt):
                 negative_prompt = f"{z} {negative_prompt}"
         return "Mod", prompt, negative_prompt.strip(), clean_negative_prompt.strip()
     return "None"
+
+
+def queue_check(author_compare):
+    user_queue = 0
+    for queue_object in queuehandler.GlobalQueue.queue:
+        if queue_object.ctx.author.id == author_compare.id:
+            user_queue += 1
+            if user_queue >= global_var.queue_limit:
+                return "Stop"
 
 
 def stats_count(number):
@@ -384,7 +394,7 @@ def populate_global_vars():
     global_var.display_ignored_words = config['display_ignored_words']
     global_var.negative_prompt_prefix = [x for x in config['negative_prompt_prefix']]
     # slash command doesn't update this dynamically. Changes to size need a restart.
-    global_var.size_range = range(192, config['max_size']+64, 64)
+    global_var.size_range = range(192, config['max_size'] + 64, 64)
 
     # create persistent session since we'll need to do a few API calls
     s = requests.Session()


### PR DESCRIPTION
This PR simplifies some of the code around the queue. I'm going to need to touch this code a lot to make any progress on projects lists, so I'd like it to be as workable as possible.

The code that checks if user has reach limit of items in queue is moved into a function. It helps de-duplicate that code, which was in five places... It helps helps de-duplicate initial/confirmation reply from AIYA in each of those five places.

There should be no noticeable change by end user.