### PR TITLE
add pnginfo to /identify

### DIFF
--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -50,11 +50,12 @@ class UpscaleObject:
 
 # the queue object for identify (interrogate)
 class IdentifyObject:
-    def __init__(self, cog, ctx, init_image, phrasing, view):
+    def __init__(self, cog, ctx, init_image, phrasing, read_info, view):
         self.cog = cog
         self.ctx = ctx
         self.init_image = init_image
         self.phrasing = phrasing
+        self.read_info = read_info
         self.view = view
 
 


### PR DESCRIPTION
This PR adds a simple option to /identify to try to grab PNG info (metadata) instead of generating a caption.

/identify has an additional option named **read_info**
![image](https://user-images.githubusercontent.com/2993060/221385436-9e1eda16-fb78-4bcf-9579-5973d6090199.png)

If selecting this option, AIYA will not generate a caption. She will instead check if the image has png info. If not,  she will state as such: 
![image](https://user-images.githubusercontent.com/2993060/221385226-39d986e4-a562-4adb-998d-bb4e69700912.png)

Otherwise, it will present the parameters in the same format as seen on the Web UI: 
![image](https://user-images.githubusercontent.com/2993060/221385236-ff4ad2d5-4097-47a4-96bc-114afba88419.png)

This could be useful for grabbing the information for old images when you need to reference what created them. It's a decent workaround until I can add button persistence between AIYA restarts.  

There isn't any simple way to convert this information into a format that would support 🖋️🎲📋, so this functionality is not included in this PR, but I may look into doing so later on.