### PR TITLE
Button minor refactor

### DIFF
--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -19,7 +19,7 @@ class IdentifyCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        self.bot.add_view(viewhandler.DrawView(self))
+        self.bot.add_view(viewhandler.DeleteView(self))
 
     @commands.slash_command(name='identify', description='Describe an image', guild_only=True)
     @option(
@@ -69,7 +69,7 @@ class IdentifyCog(commands.Cog):
 
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (ctx, init_image, phrasing)
-        view = viewhandler.DrawView(input_tuple)
+        view = viewhandler.DeleteView(input_tuple)
         # set up the queue if an image was found
         user_queue_limit = settings.queue_check(ctx.author)
         if has_image:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -513,8 +513,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                         pil_image.save(buffer, 'PNG', pnginfo=metadata)
                         buffer.seek(0)
                     draw_time = '{0:.3f}'.format(end_time - start_time)
-                    message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` ' \
-                              f'seconds!\n> *{queue_object.ctx.author.name}#{queue_object.ctx.author.discriminator}*'
+                    message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
                     files = [discord.File(fp=buffer, filename=f'{queue_object.seed}-{i}.png') for (i, buffer) in
                              enumerate(buffer_handles)]
 

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -25,6 +25,10 @@ class UpscaleCog(commands.Cog):
         self.bot = bot
         self.file_name = ''
 
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.bot.add_view(viewhandler.DrawView(self))
+
     @commands.slash_command(name='upscale', description='Upscale an image', guild_only=True)
     @option(
         'init_image',
@@ -135,7 +139,7 @@ class UpscaleCog(commands.Cog):
 
         # set up tuple of parameters
         input_tuple = (ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, gfpgan, codeformer, upscale_first)
-        view = viewhandler.DeleteView(ctx.author.id)
+        view = viewhandler.DrawView(input_tuple)
         # set up the queue if an image was found
         user_queue_limit = settings.queue_check(ctx.author)
         if has_image:
@@ -220,8 +224,7 @@ class UpscaleCog(commands.Cog):
                     buffer.seek(0)
 
                     draw_time = '{0:.3f}'.format(end_time - start_time)
-                    message = f'my upscale of ``{queue_object.resize}``x took me ``{draw_time}`` ' \
-                              f'seconds!\n> *{queue_object.ctx.author.name}#{queue_object.ctx.author.discriminator}*'
+                    message = f'my upscale of ``{queue_object.resize}``x took me ``{draw_time}`` seconds!'
                     file = discord.File(fp=buffer, filename=file_path)
 
                     queuehandler.process_post(

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -27,7 +27,7 @@ class UpscaleCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        self.bot.add_view(viewhandler.DrawView(self))
+        self.bot.add_view(viewhandler.DeleteView(self))
 
     @commands.slash_command(name='upscale', description='Upscale an image', guild_only=True)
     @option(
@@ -139,7 +139,7 @@ class UpscaleCog(commands.Cog):
 
         # set up tuple of parameters
         input_tuple = (ctx, resize, init_image, upscaler_1, upscaler_2, upscaler_2_strength, gfpgan, codeformer, upscale_first)
-        view = viewhandler.DrawView(input_tuple)
+        view = viewhandler.DeleteView(input_tuple)
         # set up the queue if an image was found
         user_queue_limit = settings.queue_check(ctx.author)
         if has_image:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -291,8 +291,7 @@ class DrawView(View):
     async def button_draw(self, button, interaction):
         try:
             # check if the output is from the person who requested it
-            end_user = f'{interaction.user.name}#{interaction.user.discriminator}'
-            if end_user in self.message.content:
+            if interaction.user.id == self.input_tuple[0].author.id:
                 # if there's room in the queue, open up the modal
                 user_queue_limit = settings.queue_check(interaction.user)
                 if queuehandler.GlobalQueue.dream_thread.is_alive():
@@ -318,8 +317,7 @@ class DrawView(View):
     async def button_roll(self, button, interaction):
         try:
             # check if the output is from the person who requested it
-            end_user = f'{interaction.user.name}#{interaction.user.discriminator}'
-            if end_user in self.message.content:
+            if interaction.user.id == self.input_tuple[0].author.id:
                 # update the tuple with a new seed
                 new_seed = list(self.input_tuple)
                 new_seed[10] = random.randint(0, 0xFFFFFFFF)
@@ -453,8 +451,7 @@ class DrawView(View):
     async def delete(self, button, interaction):
         try:
             # check if the output is from the person who requested it
-            end_user = f'{interaction.user.name}#{interaction.user.discriminator}'
-            if end_user in self.message.content:
+            if interaction.user.id == self.input_tuple[0].author.id:
                 await interaction.message.delete()
             else:
                 await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
@@ -463,21 +460,3 @@ class DrawView(View):
             await interaction.response.edit_message(view=self)
             await interaction.followup.send("I may have been restarted. This button no longer works.\n"
                                             "You can react with ❌ to delete the image.", ephemeral=True)
-
-
-# creating the view that holds a button to delete output
-class DeleteView(View):
-    def __init__(self, user):
-        super().__init__(timeout=None)
-        self.user = user
-
-    @discord.ui.button(
-        custom_id="button_x",
-        emoji="❌")
-    async def delete(self, button, interaction):
-        # check if the output is from the person who requested it
-        if interaction.user.id == self.user:
-            button.disabled = True
-            await interaction.message.delete()
-        else:
-            await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -460,3 +460,24 @@ class DrawView(View):
             await interaction.response.edit_message(view=self)
             await interaction.followup.send("I may have been restarted. This button no longer works.\n"
                                             "You can react with ❌ to delete the image.", ephemeral=True)
+
+class DeleteView(View):
+    def __init__(self, input_tuple):
+        super().__init__(timeout=None)
+        self.input_tuple = input_tuple
+
+    @discord.ui.button(
+        custom_id="button_x_solo",
+        emoji="❌")
+    async def delete(self, button, interaction):
+        try:
+            # check if the output is from the person who requested it
+            if interaction.user.id == self.input_tuple[0].author.id:
+                await interaction.message.delete()
+            else:
+                await interaction.response.send_message("You can't delete other people's images!", ephemeral=True)
+        except(Exception,):
+            button.disabled = True
+            await interaction.response.edit_message(view=self)
+            await interaction.followup.send("I may have been restarted. This button no longer works.\n"
+                                            "You can react with ❌ to delete the image.", ephemeral=True)


### PR DESCRIPTION
This PR simplifies the `View()` code a little bit.

~~Every slash command uses DrawView now (I should probably rename it)~~, and that view is persistent for each command.  
~~Remove DeleteView since it's no longer needed.~~

The code to match who clicked on the button is improved, which allows me to clean up the output reply. It always bothered me that output shows the username+descriminator (not very aesthetic)

To do:
- ~~remove 🖋️🎲📋 from /upscale and /identify outputs, since they're not needed.~~ seems like this is not actually possible, I guess? Can't find any way to send "variations" of the same view according to what cog sends it. well I can enjoy the rest of the simplified code.