### PR TITLE
Send separate messages for each image when batch is more than 1

### DIFF
--- a/core/ctxmenuhandler.py
+++ b/core/ctxmenuhandler.py
@@ -66,6 +66,9 @@ async def parse_image_info(ctx, image_url, command):
         # initialize extra params
         steps, size, guidance_scale, sampler, seed = '', '', '', '', ''
         style, facefix, highres_fix, clip_skip = '', '', '', ''
+        strength, has_init_url = '', False
+        if command == 'button' and ctx is not None:
+            has_init_url = True
 
         # try to find extra networks
         hypernet, lora = extra_net_search(prompt_field)
@@ -110,6 +113,9 @@ async def parse_image_info(ctx, image_url, command):
             if 'Clip skip: ' in line:
                 clip_skip = line.split(': ', 1)[1]
 
+            if 'Denoising strength: ' in line:
+                strength = line.split(': ', 1)[1]
+
         width_height = size.split("x")
 
         # try to find the model name and activator token
@@ -129,8 +135,9 @@ async def parse_image_info(ctx, image_url, command):
             negative_prompt = mod_results[3]
 
         # create embed and give the best effort in trying to parse the png info
-        embed = discord.Embed(title="About the image!", description="This is what I'm able to find about this image.")
-        embed.set_thumbnail(url=image_url)
+        embed = discord.Embed(title="About the image!", description="")
+        if not has_init_url:  # for some reason this bugs out the embed
+            embed.set_thumbnail(url=image_url)
         if len(prompt_field) > 1024:
             prompt_field = f'{prompt_field[:1010]}....'
         embed.colour = settings.global_var.embed_color
@@ -141,7 +148,7 @@ async def parse_image_info(ctx, image_url, command):
         copy_command = f'/draw prompt:{prompt_field} steps:{steps} width:{width_height[0]} height:{width_height[1]}' \
                        f' guidance_scale:{guidance_scale} sampler:{sampler} seed:{seed}'
         if display_name != 'Unknown':
-            copy_command += f' data_model: {display_name}'
+            copy_command += f' data_model:{display_name}'
 
         if negative_prompt != '':
             copy_command += f' negative_prompt:{negative_prompt}'
@@ -176,8 +183,15 @@ async def parse_image_info(ctx, image_url, command):
                 network_params += f'\nHypernet: ``{key}`` (multiplier: ``{value}``)'
             embed.add_field(name=f'Extra networks', value=network_params, inline=False)
 
+        if has_init_url:
+            # not interested in adding embed fields for strength and init_image
+            copy_command += f' strength:{strength} init_url:{str(ctx)}'
+
         embed.add_field(name=f'Command for copying', value=f'', inline=False)
         embed.set_footer(text=copy_command)
+
+        if command == 'button':
+            return embed
 
         await ctx.respond(embed=embed, ephemeral=True)
     except Exception as e:

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -130,7 +130,7 @@ class IdentifyCog(commands.Cog):
 
                 queuehandler.process_post(
                     self, queuehandler.PostObject(
-                        self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>', file='', files='', embed=embed, view=queue_object.view))
+                        self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>', file='', embed=embed, view=queue_object.view))
             Thread(target=post_dream, daemon=True).start()
 
         except Exception as e:

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -60,12 +60,11 @@ class IdentifyObject:
 
 # the queue object for posting to Discord
 class PostObject:
-    def __init__(self, cog, ctx, content, file, files, embed, view):
+    def __init__(self, cog, ctx, content, file, embed, view):
         self.cog = cog
         self.ctx = ctx
         self.content = content
         self.file = file
-        self.files = files
         self.embed = embed
         self.view = view
 

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -1,5 +1,4 @@
 import base64
-import contextlib
 import discord
 import io
 import math
@@ -372,7 +371,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         event_loop.create_task(
             post_queue_object.ctx.channel.send(
                 content=post_queue_object.content,
-                files=post_queue_object.files,
+                file=post_queue_object.file,
                 view=post_queue_object.view
             )
         )
@@ -462,49 +461,51 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             file_name = "".join(c for c in queue_object.simple_prompt if c.isalnum() or c in keep_chars).rstrip()
 
             # save local copy of image and prepare PIL images
-            pil_images = []
-            for i, image_base64 in enumerate(response_data['images']):
-                image = Image.open(io.BytesIO(base64.b64decode(image_base64.split(",", 1)[0])))
-                pil_images.append(image)
+            image_data = response_data['images']
+            count = 0
+            for i in image_data:
+                count += 1
+                image = Image.open(io.BytesIO(base64.b64decode(i)))
 
                 # grab png info
                 png_payload = {
-                    "image": "data:image/png;base64," + image_base64
+                    "image": "data:image/png;base64," + i
                 }
                 png_response = s.post(url=f'{settings.global_var.url}/sdapi/v1/png-info', json=png_payload)
 
                 metadata = PngImagePlugin.PngInfo()
                 metadata.add_text("parameters", png_response.json().get("info"))
 
+                epoch_time = int(time.time())
+                file_path = f'{settings.global_var.dir}/{epoch_time}-{queue_object.seed}-{file_name[0:120]}-{count}.png'
                 if settings.global_var.save_outputs == 'True':
-                    epoch_time = int(time.time())
-                    file_path = f'{settings.global_var.dir}/{epoch_time}-{queue_object.seed}-{file_name[0:120]}-{i}.png'
                     image.save(file_path, pnginfo=metadata)
                     print(f'Saved image: {file_path}')
 
-            # increment number of images generated
-            settings.stats_count(queue_object.batch[0]*queue_object.batch[1])
+                settings.stats_count(1)
 
-            # post to discord
-            def post_dream():
-                with contextlib.ExitStack() as stack:
-                    buffer_handles = [stack.enter_context(io.BytesIO()) for _ in pil_images]
-
-                    image_count = len(pil_images)
-                    noun_descriptor = "drawing" if image_count == 1 else f'{image_count} drawings'
-
-                    for (pil_image, buffer) in zip(pil_images, buffer_handles):
-                        pil_image.save(buffer, 'PNG', pnginfo=metadata)
+                # post to discord
+                def post_dream():
+                    content = ''
+                    with io.BytesIO() as buffer:
+                        image = Image.open(io.BytesIO(base64.b64decode(i)))
+                        image.save(buffer, 'PNG', pnginfo=metadata)
                         buffer.seek(0)
-                    draw_time = '{0:.3f}'.format(end_time - start_time)
-                    message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
-                    files = [discord.File(fp=buffer, filename=f'{queue_object.seed}-{i}.png') for (i, buffer) in
-                             enumerate(buffer_handles)]
 
-                    queuehandler.process_post(
-                        self, queuehandler.PostObject(
-                            self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>, {message}', file='', files=files, embed='', view=queue_object.view))
-            Thread(target=post_dream, daemon=True).start()
+                        image_count = len(image_data)
+                        noun_descriptor = "drawing" if image_count == 1 else f'{image_count} drawings'
+
+                        draw_time = '{0:.3f}'.format(end_time - start_time)
+                        message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
+                        file = discord.File(fp=buffer, filename=file_path)
+
+                        if count == 1:
+                            content = f'<@{queue_object.ctx.author.id}>, {message}'
+
+                        queuehandler.process_post(
+                            self, queuehandler.PostObject(
+                                self, queue_object.ctx, content=content, file=file, embed='', view=queue_object.view))
+                Thread(target=post_dream, daemon=True).start()
 
         except KeyError:
             embed = discord.Embed(title='txt2img failed', description=f'An invalid parameter was found!',

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -497,7 +497,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
                         draw_time = '{0:.3f}'.format(end_time - start_time)
                         message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
-                        file = discord.File(fp=buffer, filename=file_path)
+                        file = discord.File(fp=buffer, filename=f'{queue_object.seed}-{count}.png')
 
                         if count == 1:
                             content = f'<@{queue_object.ctx.author.id}>, {message}'

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -218,7 +218,7 @@ class UpscaleCog(commands.Cog):
 
                     queuehandler.process_post(
                         self, queuehandler.PostObject(
-                            self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>, {message}', file=file, files='', embed='', view=queue_object.view))
+                            self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>, {message}', file=file, embed='', view=queue_object.view))
             Thread(target=post_dream, daemon=True).start()
 
         except Exception as e:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -22,7 +22,7 @@ input_tuple[0] = ctx
 [10] = seed
 [11] = strength
 [12] = init_image
-[13] = count
+[13] = batch
 [14] = style
 [15] = facefix
 [16] = highres_fix
@@ -251,6 +251,8 @@ class DrawModal(Modal):
                 pen[2] += f' <hypernet:{pen[18]}:0.85>'
             if pen[19] != 'None':
                 pen[2] += f' <lora:{pen[19]}:0.85>'
+            # set batch to 1
+            pen[13] = [1, 1]
 
             # the updated tuple to send to queue
             prompt_tuple = tuple(pen)
@@ -264,7 +266,7 @@ class DrawModal(Modal):
                 prompt_output += f'\nNew model: ``{new_model}``'
             index_start = 5
             for index, value in enumerate(tuple_names[index_start:], index_start):
-                if index == 17:
+                if index == 13 or index == 17:
                     continue
                 if str(pen[index]) != str(self.input_tuple[index]):
                     prompt_output += f'\nNew {value}: ``{pen[index]}``'
@@ -322,6 +324,8 @@ class DrawView(View):
                 # update the tuple with a new seed
                 new_seed = list(self.input_tuple)
                 new_seed[10] = random.randint(0, 0xFFFFFFFF)
+                # set batch to 1
+                new_seed[13] = [1, 1]
                 seed_tuple = tuple(new_seed)
 
                 print(f'Reroll -- {interaction.user.name}#{interaction.user.discriminator} -- Prompt: {seed_tuple[1]}')

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -361,7 +361,7 @@ class DrawView(View):
         emoji="📋")
     async def button_review(self, button, interaction):
         # reuse "read image info" command from ctxmenuhandler
-        init_url = ''
+        init_url = None
         try:
             attachment = self.message.attachments[0]
             if self.input_tuple[12]:
@@ -393,6 +393,7 @@ class DrawView(View):
             await interaction.response.edit_message(view=self)
             await interaction.followup.send("I may have been restarted. This button no longer works.\n"
                                             "You can react with ❌ to delete the image.", ephemeral=True)
+
 
 class DeleteView(View):
     def __init__(self, input_tuple):

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -357,10 +357,12 @@ class DrawView(View):
         emoji="📋")
     async def button_review(self, button, interaction):
         # reuse "read image info" command from ctxmenuhandler
+        init_url = ''
         try:
             attachment = self.message.attachments[0]
-            init_url = self.input_tuple[12]
-            embed = await ctxmenuhandler.parse_image_info(init_url.url, attachment.url, "button")
+            if self.input_tuple[12]:
+                init_url = self.input_tuple[12].url
+            embed = await ctxmenuhandler.parse_image_info(init_url, attachment.url, "button")
             await interaction.response.send_message(embed=embed, ephemeral=True)
         except Exception as e:
             print('The clipboard button broke: ' + str(e))

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -2,6 +2,7 @@ import discord
 import random
 from discord.ui import InputText, Modal, View
 
+from core import ctxmenuhandler
 from core import queuehandler
 from core import settings
 from core import stablecog
@@ -355,87 +356,11 @@ class DrawView(View):
         custom_id="button_review",
         emoji="📋")
     async def button_review(self, button, interaction):
-        # simpler variable name
-        rev = self.input_tuple
-        # initial dummy data for a default models.csv
-        display_name = 'Default'
-        model_name, model_hash = 'Unknown', 'Unknown'
-        activator_token = ''
+        # reuse "read image info" command from ctxmenuhandler
         try:
-            # get the remaining model information we want from the data_model ("title") in the tuple
-            for model in settings.global_var.model_info.items():
-                if model[1][0] == rev[4] and model[1][0] != "Default":
-                    display_name = model[0]
-                    model_name = model[1][1]
-                    model_hash = model[1][2]
-                    if model[1][3]:
-                        activator_token = f'\nActivator token - ``{model[1][3]}``'
-                    break
-
-            # strip any folders from model name
-            model_name = model_name.split('_', 1)[-1]
-
-            # run through mod function to get clean negative since I don't want to add it to stablecog tuple
-            clean_negative = rev[3]
-            if settings.global_var.negative_prompt_prefix:
-                mod_results = settings.prompt_mod(rev[2], rev[3])
-                if settings.global_var.negative_prompt_prefix and mod_results[0] == "Mod":
-                    clean_negative = mod_results[3]
-
-            # generate the command for copy-pasting, and also add embed fields
-            embed = discord.Embed(title="About the image!", description="")
-            prompt_field = rev[1]
-            if len(prompt_field) > 1024:
-                prompt_field = f'{prompt_field[:1010]}....'
-            embed.colour = settings.global_var.embed_color
-            embed.add_field(name=f'Prompt', value=f'``{prompt_field}``', inline=False)
-            embed.add_field(name='Data model', value=f'Display name - ``{display_name}``\nModel name - ``{model_name}``'
-                                                     f'\nShorthash - ``{model_hash}``{activator_token}', inline=False)
-
-            copy_command = f'/draw prompt:{rev[1]} data_model:{display_name} steps:{rev[5]} width:{rev[6]} ' \
-                           f'height:{rev[7]} guidance_scale:{rev[8]} sampler:{rev[9]} seed:{rev[10]}'
-            if rev[3] != '':
-                copy_command += f' negative_prompt:{clean_negative}'
-                n_prompt_field = clean_negative
-                if len(n_prompt_field) > 1024:
-                    n_prompt_field = f'{n_prompt_field[:1010]}....'
-                embed.add_field(name=f'Negative prompt', value=f'``{n_prompt_field}``', inline=False)
-
-            extra_params = f'Sampling steps: ``{rev[5]}``\nSize: ``{rev[6]}x{rev[7]}``\nClassifier-free guidance ' \
-                           f'scale: ``{rev[8]}``\nSampling method: ``{rev[9]}``\nSeed: ``{rev[10]}``'
-            if rev[12]:
-                # not interested in adding embed fields for strength and init_image
-                copy_command += f' strength:{rev[11]} init_url:{rev[12].url}'
-            if rev[13][0] != 1 or rev[13][1] != 1:
-                bat_string = ','.join(str(x) for x in rev[13])
-                bat_copy = settings.batch_format(bat_string)
-                copy_command += f' batch:{bat_copy[0]},{bat_copy[1]}'
-            if rev[14] != 'None':
-                copy_command += f' styles:{rev[14]}'
-                extra_params += f'\nStyle preset: ``{rev[14]}``'
-            if rev[15] != 'None':
-                copy_command += f' facefix:{rev[15]}'
-                extra_params += f'\nFace restoration model: ``{rev[15]}``'
-            if rev[16] != 'Disabled':
-                copy_command += f' highres_fix:{rev[16]}'
-                extra_params += f'\nHigh-res fix: ``{rev[16]}``'
-            if rev[17] != 1:
-                copy_command += f' clip_skip:{rev[17]}'
-                extra_params += f'\nCLIP skip: ``{rev[17]}``'
-            if rev[18] != 'None':
-                copy_command += f' hypernet:{rev[18]}'
-                extra_params += f'\nHypernetwork model: ``{rev[18]}``'
-            if rev[19] != 'None':
-                copy_command += f' lora:{rev[19]}'
-                extra_params += f'\nLoRA model: ``{rev[19]}``'
-            embed.add_field(name=f'Other parameters', value=extra_params, inline=False)
-            embed.add_field(name=f'Command for copying', value=f'', inline=False)
-            embed.set_footer(text=copy_command)
-            if len(copy_command) > 2048:
-                button.disabled = True
-                await interaction.response.edit_message(view=self)
-                await interaction.followup.send("The contents of 📋 exceeded Discord's character limit! Sorry, I can't display it...", ephemeral=True)
-
+            attachment = self.message.attachments[0]
+            init_url = self.input_tuple[12]
+            embed = await ctxmenuhandler.parse_image_info(init_url.url, attachment.url, "button")
             await interaction.response.send_message(embed=embed, ephemeral=True)
         except Exception as e:
             print('The clipboard button broke: ' + str(e))
@@ -443,7 +368,7 @@ class DrawView(View):
             button.disabled = True
             await interaction.response.edit_message(view=self)
             await interaction.followup.send("I may have been restarted. This button no longer works.\n"
-                                            "You can try to get the image info from **/identify** or the context menu.",
+                                            "You can get the image info from the context menu or **/identify**.",
                                             ephemeral=True)
 
     # the button to delete generated images


### PR DESCRIPTION
This PR simply does as title suggests.

It will look something like this:  
![image](https://user-images.githubusercontent.com/2993060/222895579-278c166e-f69d-4270-8a46-b297718e0917.png)

This should solve issues such as Discord's 10 attachments per message limit and provide greater control over each output image.

todo:
- make sure buttons work for each message and is giving the correct info

