### PR TITLE
Send separate messages for each image when batch is more than 1, part 2

### DIFF
--- a/core/infocog.py
+++ b/core/infocog.py
@@ -287,18 +287,24 @@ class InfoView(View):
         embed_tips4.add_field(name="❌",
                               value="The button used to delete any unwanted outputs. If this button isn't working, you can add a ❌ reaction instead.")
         embed_tips4.add_field(name="\u200B", value="\u200B")
+
+        embed_tips5 = discord.Embed(title="Context menu",
+                                    description="You have the option to use context menu commands on any message!\n"
+                                                "To use the commands, right-click (or tap and hold) any message then find me under 'Apps'.\n"
+                                                "\nThe context menu is useful if you need to interact with images when the buttons are missing or broken, or even interacting with images not created by me.",
+                                    colour=settings.global_var.embed_color)
         # For those who fork AIYA, feel free to edit or add to this per your needs,
         # but please don't just delete me from credits and claim my work as yours.
         url = 'https://github.com/Kilvoctu/aiyabot'
         thumb = 'https://raw.githubusercontent.com/Kilvoctu/kilvoctu.github.io/master/pics/previewthumb.png'
         wiki = 'https://github.com/Kilvoctu/aiyabot/wiki#using-aiya'
-        embed_tips5 = discord.Embed(title="Extra Information",
+        embed_tips6 = discord.Embed(title="Extra Information",
                                     description=f"For more detailed documentation, check out the [wiki]({wiki}) in my [home]({url})!\n\n"
                                                 f"Also, feel free to report bugs or leave feedback! I'm open-source Python Discord bot AIYA, developed by *Kilvoctu#1238*, maintained with care."
                                                 f"\n\nPlease enjoy making AI art with me~!",
                                     colour=settings.global_var.embed_color)
-        embed_tips5.set_thumbnail(url=thumb)
-        embed_tips5.set_footer(text='Have a lovely day!', icon_url=thumb)
+        embed_tips6.set_thumbnail(url=thumb)
+        embed_tips6.set_footer(text='Have a lovely day!', icon_url=thumb)
 
         self.page = 0
         self.contents = [
@@ -306,7 +312,8 @@ class InfoView(View):
             embed_tips2,
             embed_tips3,
             embed_tips4,
-            embed_tips5
+            embed_tips5,
+            embed_tips6
         ]
 
         await interaction.response.edit_message(view=self, embed=self.contents[0])

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -348,7 +348,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
     # the function to queue Discord posts
     def post(self, event_loop: queuehandler.GlobalQueue.post_event_loop, post_queue_object: queuehandler.PostObject):
-        print(f'post_queue seed - {post_queue_object.view.input_tuple[10]}')
         event_loop.create_task(
             post_queue_object.ctx.channel.send(
                 content=post_queue_object.content,
@@ -472,11 +471,16 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 draw_time = '{0:.3f}'.format(end_time - start_time)
                 message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
 
+                view = queue_object.view
                 if count == 1:
                     content = f'<@{queue_object.ctx.author.id}>, {message}'
-
-                view = queue_object.view
-                print(f'count - {count}, seed - {view.input_tuple[10]}')
+                # only enable buttons on last image in batch
+                if len(image_data) > 1:
+                    if count == 1:
+                        content = f'<@{queue_object.ctx.author.id}>, {message}\n' \
+                                  f'*Please use the context menu if you need to review drawings without buttons.*'
+                    if count != len(image_data):
+                        view = None
 
                 # post to discord
                 with io.BytesIO() as buffer:
@@ -488,11 +492,11 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     queuehandler.process_post(
                         self, queuehandler.PostObject(
                             self, queue_object.ctx, content=content, file=file, embed='', view=view))
-                # increment seed for view when using batch
-                batch_seed = list(queue_object.view.input_tuple)
+                # increment seed for view when using batch (on hold until can fix buttons)
+                '''batch_seed = list(queue_object.view.input_tuple)
                 batch_seed[10] += 1
                 new_tuple = tuple(batch_seed)
-                queue_object.view.input_tuple = new_tuple
+                queue_object.view.input_tuple = new_tuple'''
 
         except KeyError:
             embed = discord.Embed(title='txt2img failed', description=f'An invalid parameter was found!',

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -10,7 +10,6 @@ from asyncio import AbstractEventLoop
 from PIL import Image, PngImagePlugin
 from discord import option
 from discord.ext import commands
-from threading import Thread
 from typing import Optional
 
 from core import queuehandler
@@ -350,6 +349,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
     # the function to queue Discord posts
     def post(self, event_loop: AbstractEventLoop, post_queue_object: queuehandler.PostObject):
+        print(f'post_queue seed - {post_queue_object.view.input_tuple[10]}')
         event_loop.create_task(
             post_queue_object.ctx.channel.send(
                 content=post_queue_object.content,
@@ -466,28 +466,35 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
 
                 settings.stats_count(1)
 
+                # set up discord message
+                content = ''
+                image_count = len(image_data)
+                noun_descriptor = "drawing" if image_count == 1 else f'{image_count} drawings'
+                draw_time = '{0:.3f}'.format(end_time - start_time)
+                message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
+
+                batch_seed = list(queue_object.view.input_tuple)
+
+                if count == 1:
+                    content = f'<@{queue_object.ctx.author.id}>, {message}'
+                    batch_seed[10] -= 1
+
+                batch_seed[10] += 1
+                new_tuple = tuple(batch_seed)
+                queue_object.view.input_tuple = new_tuple
+                new_view = queue_object.view
+                print(f'count - {count}, new seed - {new_view.input_tuple[10]}')
+
                 # post to discord
-                def post_dream():
-                    content = ''
-                    image_count = len(image_data)
-                    noun_descriptor = "drawing" if image_count == 1 else f'{image_count} drawings'
-                    draw_time = '{0:.3f}'.format(end_time - start_time)
-                    message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
+                with io.BytesIO() as buffer:
+                    image = Image.open(io.BytesIO(base64.b64decode(i)))
+                    image.save(buffer, 'PNG', pnginfo=metadata)
+                    buffer.seek(0)
 
-                    if count == 1:
-                        content = f'<@{queue_object.ctx.author.id}>, {message}'
-
-                    with io.BytesIO() as buffer:
-                        image = Image.open(io.BytesIO(base64.b64decode(i)))
-                        image.save(buffer, 'PNG', pnginfo=metadata)
-                        buffer.seek(0)
-
-                        file = discord.File(fp=buffer, filename=f'{queue_object.seed}-{count}.png')
-
-                        queuehandler.process_post(
-                            self, queuehandler.PostObject(
-                                self, queue_object.ctx, content=content, file=file, embed='', view=queue_object.view))
-                Thread(target=post_dream, daemon=True).start()
+                    file = discord.File(fp=buffer, filename=f'{queue_object.seed}-{count}.png')
+                    queuehandler.process_post(
+                        self, queuehandler.PostObject(
+                            self, queue_object.ctx, content=content, file=file, embed='', view=new_view))
 
         except KeyError:
             embed = discord.Embed(title='txt2img failed', description=f'An invalid parameter was found!',

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -492,11 +492,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     queuehandler.process_post(
                         self, queuehandler.PostObject(
                             self, queue_object.ctx, content=content, file=file, embed='', view=view))
-                # increment seed for view when using batch (on hold until can fix buttons)
-                '''batch_seed = list(queue_object.view.input_tuple)
-                batch_seed[10] += 1
-                new_tuple = tuple(batch_seed)
-                queue_object.view.input_tuple = new_tuple'''
+                # increment seed for view when using batch
+                if count != len(image_data):
+                    batch_seed = list(queue_object.view.input_tuple)
+                    batch_seed[10] += 1
+                    new_tuple = tuple(batch_seed)
+                    queue_object.view.input_tuple = new_tuple
 
         except KeyError:
             embed = discord.Embed(title='txt2img failed', description=f'An invalid parameter was found!',

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -6,7 +6,6 @@ import random
 import requests
 import time
 import traceback
-from asyncio import AbstractEventLoop
 from PIL import Image, PngImagePlugin
 from discord import option
 from discord.ext import commands
@@ -348,7 +347,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             await ctx.send_response(f'<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - ``{simple_prompt}``\nSteps: ``{steps}``{reply_adds}')
 
     # the function to queue Discord posts
-    def post(self, event_loop: AbstractEventLoop, post_queue_object: queuehandler.PostObject):
+    def post(self, event_loop: queuehandler.GlobalQueue.post_event_loop, post_queue_object: queuehandler.PostObject):
         print(f'post_queue seed - {post_queue_object.view.input_tuple[10]}')
         event_loop.create_task(
             post_queue_object.ctx.channel.send(
@@ -361,7 +360,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             self.post(self.event_loop, self.queue.pop(0))
 
     # generate the image
-    def dream(self, event_loop: AbstractEventLoop, queue_object: queuehandler.DrawObject):
+    def dream(self, event_loop: queuehandler.GlobalQueue.event_loop, queue_object: queuehandler.DrawObject):
         try:
             start_time = time.time()
 
@@ -467,23 +466,17 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 settings.stats_count(1)
 
                 # set up discord message
-                content = ''
+                content = f'<@{queue_object.ctx.author.id}>'
                 image_count = len(image_data)
                 noun_descriptor = "drawing" if image_count == 1 else f'{image_count} drawings'
                 draw_time = '{0:.3f}'.format(end_time - start_time)
                 message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
 
-                batch_seed = list(queue_object.view.input_tuple)
-
                 if count == 1:
                     content = f'<@{queue_object.ctx.author.id}>, {message}'
-                    batch_seed[10] -= 1
 
-                batch_seed[10] += 1
-                new_tuple = tuple(batch_seed)
-                queue_object.view.input_tuple = new_tuple
-                new_view = queue_object.view
-                print(f'count - {count}, new seed - {new_view.input_tuple[10]}')
+                view = queue_object.view
+                print(f'count - {count}, seed - {view.input_tuple[10]}')
 
                 # post to discord
                 with io.BytesIO() as buffer:
@@ -494,7 +487,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     file = discord.File(fp=buffer, filename=f'{queue_object.seed}-{count}.png')
                     queuehandler.process_post(
                         self, queuehandler.PostObject(
-                            self, queue_object.ctx, content=content, file=file, embed='', view=new_view))
+                            self, queue_object.ctx, content=content, file=file, embed='', view=view))
+                # increment seed for view when using batch
+                batch_seed = list(queue_object.view.input_tuple)
+                batch_seed[10] += 1
+                new_tuple = tuple(batch_seed)
+                queue_object.view.input_tuple = new_tuple
 
         except KeyError:
             embed = discord.Embed(title='txt2img failed', description=f'An invalid parameter was found!',

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -361,8 +361,6 @@ class DrawView(View):
         emoji="📋")
     async def button_review(self, button, interaction):
         # reuse "read image info" command from ctxmenuhandler
-        print(self.message.id)
-        print(self.input_tuple[10])
         init_url = None
         try:
             attachment = self.message.attachments[0]

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -361,6 +361,8 @@ class DrawView(View):
         emoji="📋")
     async def button_review(self, button, interaction):
         # reuse "read image info" command from ctxmenuhandler
+        print(self.message.id)
+        print(self.input_tuple[10])
         init_url = None
         try:
             attachment = self.message.attachments[0]


### PR DESCRIPTION
edit: check out https://github.com/Kilvoctu/aiyabot/pull/136#issuecomment-1457289530

---

This PR is part 2 of PR #134. ~~Its changes start from commit bbda0f44d064ddee7557bcc1c4fa387a789e9fb7~~ rebased

Essentially, when user does a batch of images, each image has its own set of buttons; that's already done.  
The issue is that all the buttons in the batch only have the attributes of the very last image in the batch.

My code already has a separate queue for posting to Discord. The idea is to utilize this: for each image in the queue (when batch is more than 1) edit the buttons manually to have the correct attributes, but for some reason it's not successful.