### PR TITLE
Add upscale to context menu

### DIFF
--- a/aiya.py
+++ b/aiya.py
@@ -44,6 +44,11 @@ async def get_image_info(ctx, message: discord.Message):
     await ctxmenuhandler.get_image_info(ctx, message)
 
 
+@self.message_command(name="Quick 2x Upscale")
+async def quick_upscale(ctx, message: discord.Message):
+    await ctxmenuhandler.quick_upscale(self, ctx, message)
+
+
 @self.event
 async def on_ready():
     self.logger.info(f'Logged in as {self.user.name} ({self.user.id})')

--- a/core/ctxmenuhandler.py
+++ b/core/ctxmenuhandler.py
@@ -262,7 +262,7 @@ async def quick_upscale(self, ctx, message: discord.Message):
                 content=f"Please wait! You're past your queue limit of {settings.global_var.queue_limit}.",
                 ephemeral=True)
         else:
-            queuehandler.GlobalQueue.queue.append(queuehandler.UpscaleObject(upscalecog.UpscaleCog, *input_tuple, view))
+            queuehandler.GlobalQueue.queue.append(queuehandler.UpscaleObject(upscale_dream, *input_tuple, view))
     else:
         await queuehandler.process_dream(upscale_dream, queuehandler.UpscaleObject(upscale_dream, *input_tuple, view))
     if user_queue_limit != "Stop":


### PR DESCRIPTION
This PR will add "Quick 2x Upscale" to the context menu.  
![image](https://user-images.githubusercontent.com/2993060/223380799-e105b292-e3be-42bb-945e-2abe1dbd8b0f.png)

This context menu option has no parameters to select. If a message contains an image, AIYA will do a upscale request, resizing the image by 2 times using the channel's default upscaler.

If a message contains multiple images, only the first will be selected.  

This command still uses the queue.