### PR TITLE
Combine hypernet and lora into extra_net

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ To generate an image from text, use the /draw command and include your prompt as
 - sampling method
 - seed
 - Web UI styles
+- extra networks (hypernetwork, LoRA)
 - face restoration
 - high-res fix
 - CLIP skip
-- hypernetworks
-- LoRA
 - img2img
 - denoising strength
 - batch count

--- a/core/infocog.py
+++ b/core/infocog.py
@@ -64,7 +64,10 @@ class InfoView(View):
             self.page += 1
         self.page = 0
 
-        await interaction.response.edit_message(view=self, embed=self.contents[0])
+        try:
+            await interaction.response.edit_message(view=self, embed=self.contents[0])
+        except(Exception,):
+            await interaction.followup.send(view=self, embed=self.contents[0], ephemeral=True)
 
     @discord.ui.button(
         custom_id="button_styles",
@@ -102,7 +105,10 @@ class InfoView(View):
             self.page += 1
         self.page = 0
 
-        await interaction.response.edit_message(view=self, embed=self.contents[0])
+        try:
+            await interaction.response.edit_message(view=self, embed=self.contents[0])
+        except(Exception,):
+            await interaction.followup.send(view=self, embed=self.contents[0], ephemeral=True)
 
     @discord.ui.button(
         custom_id="button_hyper",
@@ -136,7 +142,10 @@ class InfoView(View):
             self.page += 1
         self.page = 0
 
-        await interaction.response.edit_message(view=self, embed=self.contents[0])
+        try:
+            await interaction.response.edit_message(view=self, embed=self.contents[0])
+        except(Exception,):
+            await interaction.followup.send(view=self, embed=self.contents[0], ephemeral=True)
 
     @discord.ui.button(
         custom_id="button_lora",

--- a/core/infocog.py
+++ b/core/infocog.py
@@ -112,7 +112,8 @@ class InfoView(View):
         batch = 16
         self.page = 0
         self.contents = []
-        desc = 'To add manually to prompt, use <hypernet:``name``:``#``>\n``#`` = The effect multiplier (0.0 - 1.0)'
+        desc = 'Select using the `extra_network` option.\n' \
+               'To add manually to prompt, use <hypernet:``name``:``#``>\n``#`` = The effect multiplier (0.0 - 1.0)'
 
         if length > batch * 2:
             self.enable_nav_buttons()
@@ -145,7 +146,8 @@ class InfoView(View):
         batch = 16
         self.page = 0
         self.contents = []
-        desc = 'To add manually to prompt, use <lora:``name``:``#``>\n``#`` = The effect multiplier (0.0 - 1.0)'
+        desc = 'Select using the `extra_network` option.\n' \
+               'To add manually to prompt, use <lora:``name``:``#``>\n``#`` = The effect multiplier (0.0 - 1.0)'
 
         if length > batch * 2:
             self.enable_nav_buttons()

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -6,7 +6,7 @@ from threading import Thread
 class DrawObject:
     def __init__(self, cog, ctx, simple_prompt, prompt, negative_prompt, data_model, steps, width, height,
                  guidance_scale, sampler, seed, strength, init_image, batch, styles, facefix, highres_fix,
-                 clip_skip, hypernet, lora, view):
+                 clip_skip, extra_net, view):
         self.cog = cog
         self.ctx = ctx
         self.simple_prompt = simple_prompt
@@ -26,8 +26,7 @@ class DrawObject:
         self.facefix = facefix
         self.highres_fix = highres_fix
         self.clip_skip = clip_skip
-        self.hypernet = hypernet
-        self.lora = lora
+        self.extra_net = extra_net
         self.view = view
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -96,6 +96,7 @@ class GlobalVar:
     embeddings_2 = []
     hyper_names = []
     lora_names = []
+    extra_nets = []
     upscaler_names = []
     hires_upscaler_names = []
     save_outputs = "True"
@@ -499,5 +500,7 @@ def populate_global_vars():
     if 'None' not in global_var.hyper_names:
         global_var.hyper_names.insert(0, 'None')
     global_var.lora_names.remove('')
+    global_var.extra_nets = global_var.hyper_names + global_var.lora_names
     global_var.lora_names.insert(0, 'None')
     global_var.hires_upscaler_names.insert(0, 'Disabled')
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -29,7 +29,9 @@ template = {
     "highres_fix": 'Disabled',
     "clip_skip": 1,
     "hypernet": "None",
+    "hyper_multi": "0.85",
     "lora": "None",
+    "lora_multi": "0.85",
     "strength": "0.75",
     "batch": "1,1",
     "max_batch": "1,1",
@@ -183,12 +185,14 @@ def extra_net_check(prompt, extra_net, net_multi):
 def extra_net_defaults(prompt, channel):
     check(channel)
     hypernet = read(channel)['hypernet']
+    hyper_multi = read(channel)['hyper_multi']
     lora = read(channel)['lora']
+    lora_multi = read(channel)['lora_multi']
     # append channel default hypernet or lora to the prompt
     if hypernet != 'None' and hypernet not in prompt:
-        prompt += f' <hypernet:{hypernet}:0.85>'
+        prompt += f' <hypernet:{hypernet}:{hyper_multi}>'
     if lora != 'None' and lora not in prompt:
-        prompt += f' <lora:{lora}:0.85>'
+        prompt += f' <lora:{lora}:{lora_multi}>'
     return prompt
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -158,6 +158,28 @@ def prompt_mod(prompt, negative_prompt):
     return "None"
 
 
+def extra_net_check(prompt, extra_net, net_multi):
+    # grab extra net multiplier if there is one
+    if ':' in extra_net:
+        net_multi = extra_net.split(':', 1)[1]
+        extra_net = extra_net.split(':', 1)[0]
+        try:
+            net_multi = net_multi.replace(",", ".")
+            float(net_multi)
+        except(Exception,):
+            # set default if invalid net multiplier is given
+            net_multi = 0.85
+    # figure out what extra_net was used
+    if extra_net is not None and extra_net != 'None':
+        for network in global_var.hyper_names:
+            if extra_net == network:
+                prompt += f' <hypernet:{extra_net}:{str(net_multi)}>'
+        for network in global_var.lora_names:
+            if extra_net == network:
+                prompt += f' <lora:{extra_net}:{str(net_multi)}>'
+    return prompt, extra_net, net_multi
+
+
 def queue_check(author_compare):
     user_queue = 0
     for queue_object in queuehandler.GlobalQueue.queue:

--- a/core/settings.py
+++ b/core/settings.py
@@ -180,6 +180,18 @@ def extra_net_check(prompt, extra_net, net_multi):
     return prompt, extra_net, net_multi
 
 
+def extra_net_defaults(prompt, channel):
+    check(channel)
+    hypernet = read(channel)['hypernet']
+    lora = read(channel)['lora']
+    # append channel default hypernet or lora to the prompt
+    if hypernet != 'None' and hypernet not in prompt:
+        prompt += f' <hypernet:{hypernet}:0.85>'
+    if lora != 'None' and lora not in prompt:
+        prompt += f' <lora:{lora}:0.85>'
+    return prompt
+
+
 def queue_check(author_compare):
     user_queue = 0
     for queue_object in queuehandler.GlobalQueue.queue:
@@ -525,4 +537,3 @@ def populate_global_vars():
     global_var.extra_nets = global_var.hyper_names + global_var.lora_names
     global_var.lora_names.insert(0, 'None')
     global_var.hires_upscaler_names.insert(0, 'Disabled')
-

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -34,6 +34,11 @@ class SettingsCog(commands.Cog):
             lora for lora in settings.global_var.lora_names
         ]
 
+    def extra_net_autocomplete(self: discord.AutocompleteContext):
+        return [
+            extra for extra in settings.global_var.extra_nets
+        ]
+
     def upscaler_autocomplete(self: discord.AutocompleteContext):
         return [
             upscaler for upscaler in settings.global_var.upscaler_names

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -211,6 +211,7 @@ class SettingsCog(commands.Cog):
         embed.set_footer(text=f'Channel id: {channel}')
         embed.colour = settings.global_var.embed_color
         current, new, new_n_prompt = '', '', ''
+        dummy_prompt, lora_multi, hyper_multi = '', 0.85, 0.85
         set_new = False
 
         if current_settings:
@@ -315,13 +316,23 @@ class SettingsCog(commands.Cog):
             set_new = True
 
         if hypernet is not None:
+            message = ''
+            if ':' in hypernet:
+                dummy_prompt, hypernet, hyper_multi = settings.extra_net_check(dummy_prompt, hypernet, hyper_multi)
+                settings.update(channel, 'hypernet_multi', hyper_multi)
+                message = f' (multiplier: ``{hyper_multi}``)'
             settings.update(channel, 'hypernet', hypernet)
-            new += f'\nHypernet: ``"{hypernet}"``'
+            new += f'\nHypernet: ``"{hypernet}"``{message}'
             set_new = True
 
         if lora is not None:
+            message = ''
+            if ':' in lora:
+                dummy_prompt, lora, lora_multi = settings.extra_net_check(dummy_prompt, lora, lora_multi)
+                settings.update(channel, 'lora_multi', lora_multi)
+                message = f' (multiplier: ``{lora_multi}``)'
             settings.update(channel, 'lora', lora)
-            new += f'\nLoRA: ``"{lora}"``'
+            new += f'\nLoRA: ``"{lora}"``{message}'
             set_new = True
 
         if strength is not None:

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -36,7 +36,7 @@ class SettingsCog(commands.Cog):
 
     def extra_net_autocomplete(self: discord.AutocompleteContext):
         return [
-            extra for extra in settings.global_var.extra_nets
+            network for network in settings.global_var.extra_nets
         ]
 
     def upscaler_autocomplete(self: discord.AutocompleteContext):
@@ -118,6 +118,20 @@ class SettingsCog(commands.Cog):
         autocomplete=discord.utils.basic_autocomplete(style_autocomplete),
     )
     @option(
+        'hypernet',
+        str,
+        description='Set default hypernetwork model for the channel',
+        required=False,
+        autocomplete=discord.utils.basic_autocomplete(hyper_autocomplete),
+    )
+    @option(
+        'lora',
+        str,
+        description='Set default LoRA for the channel',
+        required=False,
+        autocomplete=discord.utils.basic_autocomplete(lora_autocomplete),
+    )
+    @option(
         'facefix',
         str,
         description='Tries to improve faces in images.',
@@ -137,20 +151,6 @@ class SettingsCog(commands.Cog):
         description='Set default CLIP skip for the channel',
         required=False,
         choices=[x for x in range(1, 13, 1)]
-    )
-    @option(
-        'hypernet',
-        str,
-        description='Set default hypernetwork model for the channel',
-        required=False,
-        autocomplete=discord.utils.basic_autocomplete(hyper_autocomplete),
-    )
-    @option(
-        'lora',
-        str,
-        description='Set default LoRA for the channel',
-        required=False,
-        autocomplete=discord.utils.basic_autocomplete(lora_autocomplete),
     )
     @option(
         'strength',
@@ -192,11 +192,11 @@ class SettingsCog(commands.Cog):
                                guidance_scale: Optional[str] = None,
                                sampler: Optional[str] = None,
                                styles: Optional[str] = None,
+                               hypernet: Optional[str] = None,
+                               lora: Optional[str] = None,
                                facefix: Optional[str] = None,
                                highres_fix: Optional[str] = None,
                                clip_skip: Optional[int] = None,
-                               hypernet: Optional[str] = None,
-                               lora: Optional[str] = None,
                                strength: Optional[str] = None,
                                batch: Optional[str] = None,
                                max_batch: Optional[str] = None,

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -163,7 +163,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             init_url: Optional[str],
                             batch: Optional[str] = None):
 
-        hypernet, lora = None, None
         # update defaults with any new defaults from settingscog
         channel = '% s' % ctx.channel.id
         settings.check(channel)
@@ -187,10 +186,6 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             highres_fix = settings.read(channel)['highres_fix']
         if clip_skip is None:
             clip_skip = settings.read(channel)['clip_skip']
-        if hypernet is None:
-            hypernet = settings.read(channel)['hypernet']
-        if lora is None:
-            lora = settings.read(channel)['lora']
         if strength is None:
             strength = settings.read(channel)['strength']
         if batch is None:
@@ -229,11 +224,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         net_multi = 0.85
         if extra_net is not None:
             prompt, extra_net, net_multi = settings.extra_net_check(prompt, extra_net, net_multi)
-        # append any channel default hypernet or lora to the prompt
-        if hypernet != 'None':
-            prompt += f' <hypernet:{hypernet}:0.85>'
-        if lora != 'None':
-            prompt += f' <lora:{lora}:0.85>'
+        prompt = settings.extra_net_defaults(prompt, channel)
 
         if data_model != '':
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -231,14 +231,24 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             prompt += f' <hypernet:{hypernet}:0.85>'
         if lora != 'None':
             prompt += f' <lora:{lora}:0.85>'
+        # grab extra net multiplier if there is one
+        net_multi = 0.85
+        if ':' in extra_net:
+            net_multi = extra_net.split(':', 1)[1]
+            extra_net = extra_net.split(':', 1)[0]
+            try:
+                net_multi = net_multi.replace(",", ".")
+                float(net_multi)
+            except(Exception,):
+                net_multi = 0.85
         # figure out what extra_net was used
         if extra_net is not None and extra_net != 'None':
             for network in settings.global_var.hyper_names:
                 if extra_net == network:
-                    prompt += f' <hypernet:{extra_net}:0.85>'
+                    prompt += f' <hypernet:{extra_net}:{str(net_multi)}>'
             for network in settings.global_var.lora_names:
                 if extra_net == network:
-                    prompt += f' <lora:{extra_net}:0.85>'
+                    prompt += f' <lora:{extra_net}:{str(net_multi)}>'
 
         if data_model != '':
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
@@ -323,6 +333,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nStyle: ``{styles}``'
         if extra_net is not None and extra_net != 'None':
             reply_adds += f'\nExtra network: ``{extra_net}``'
+            if net_multi != 0.85:
+                reply_adds += f' (multiplier: ``{net_multi}``)'
         if facefix != settings.read(channel)['facefix']:
             reply_adds += f'\nFace restoration: ``{facefix}``'
         if clip_skip != settings.read(channel)['clip_skip']:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -154,10 +154,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             sampler: Optional[str] = None,
                             seed: Optional[int] = -1,
                             styles: Optional[str] = None,
+                            extra_net: Optional[str] = None,
                             facefix: Optional[str] = None,
                             highres_fix: Optional[str] = None,
                             clip_skip: Optional[int] = None,
-                            extra_net: Optional[str] = None,
                             strength: Optional[str] = None,
                             init_image: Optional[discord.Attachment] = None,
                             init_url: Optional[str],
@@ -226,11 +226,19 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     prompt = model[1][3] + " " + prompt
                 break
 
-        # if a hypernet or lora is used, append it to the prompt
+        # append any channel default hypernet or lora to the prompt
         if hypernet != 'None':
             prompt += f' <hypernet:{hypernet}:0.85>'
         if lora != 'None':
             prompt += f' <lora:{lora}:0.85>'
+        # figure out what extra_net was used
+        if extra_net is not None and extra_net != 'None':
+            for network in settings.global_var.hyper_names:
+                if extra_net == network:
+                    prompt += f' <hypernet:{extra_net}:0.85>'
+            for network in settings.global_var.lora_names:
+                if extra_net == network:
+                    prompt += f' <lora:{extra_net}:0.85>'
 
         if data_model != '':
             print(f'Request -- {ctx.author.name}#{ctx.author.discriminator} -- Prompt: {prompt}')
@@ -313,8 +321,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nBatch count: ``{batch[0]}`` - Batch size: ``{batch[1]}``'
         if styles != settings.read(channel)['style']:
             reply_adds += f'\nStyle: ``{styles}``'
-        if extra_net is not None:
-            reply_adds += f'\nExtra network: ``{hypernet}``'
+        if extra_net is not None and extra_net != 'None':
+            reply_adds += f'\nExtra network: ``{extra_net}``'
         if facefix != settings.read(channel)['facefix']:
             reply_adds += f'\nFace restoration: ``{facefix}``'
         if clip_skip != settings.read(channel)['clip_skip']:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -116,18 +116,11 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         choices=[x for x in range(1, 13, 1)]
     )
     @option(
-        'hypernet',
+        'extra_net',
         str,
-        description='Apply a hypernetwork model to influence the output.',
+        description='Apply an extra network to influence the output.',
         required=False,
-        autocomplete=discord.utils.basic_autocomplete(settingscog.SettingsCog.hyper_autocomplete),
-    )
-    @option(
-        'lora',
-        str,
-        description='Apply a LoRA model to influence the output.',
-        required=False,
-        autocomplete=discord.utils.basic_autocomplete(settingscog.SettingsCog.lora_autocomplete),
+        autocomplete=discord.utils.basic_autocomplete(settingscog.SettingsCog.extra_net_autocomplete),
     )
     @option(
         'strength',
@@ -164,13 +157,13 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             facefix: Optional[str] = None,
                             highres_fix: Optional[str] = None,
                             clip_skip: Optional[int] = None,
-                            hypernet: Optional[str] = None,
-                            lora: Optional[str] = None,
+                            extra_net: Optional[str] = None,
                             strength: Optional[str] = None,
                             init_image: Optional[discord.Attachment] = None,
                             init_url: Optional[str],
                             batch: Optional[str] = None):
 
+        hypernet, lora = None, None
         # update defaults with any new defaults from settingscog
         channel = '% s' % ctx.channel.id
         settings.check(channel)
@@ -320,10 +313,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             reply_adds += f'\nBatch count: ``{batch[0]}`` - Batch size: ``{batch[1]}``'
         if styles != settings.read(channel)['style']:
             reply_adds += f'\nStyle: ``{styles}``'
-        if hypernet != settings.read(channel)['hypernet']:
-            reply_adds += f'\nHypernet: ``{hypernet}``'
-        if lora != settings.read(channel)['lora']:
-            reply_adds += f'\nLoRA: ``{lora}``'
+        if extra_net is not None:
+            reply_adds += f'\nExtra network: ``{hypernet}``'
         if facefix != settings.read(channel)['facefix']:
             reply_adds += f'\nFace restoration: ``{facefix}``'
         if clip_skip != settings.read(channel)['clip_skip']:
@@ -332,7 +323,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (
             ctx, simple_prompt, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler, seed, strength,
-            init_image, batch, styles, facefix, highres_fix, clip_skip, hypernet, lora)
+            init_image, batch, styles, facefix, highres_fix, clip_skip, extra_net)
         view = viewhandler.DrawView(input_tuple)
         # setup the queue
         user_queue_limit = settings.queue_check(ctx.author)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -236,11 +236,14 @@ class DrawModal(Modal):
             # update the prompt again if a valid model change is requested
             if model_found:
                 pen[2] = new_token + pen[1]
-            # if a hypernetwork or lora is added, append it to prompt
+            # figure out what extra_net was used
             if pen[18] != 'None':
-                pen[2] += f' <hypernet:{pen[18]}:0.85>'
-            if pen[19] != 'None':
-                pen[2] += f' <lora:{pen[19]}:0.85>'
+                for network in settings.global_var.hyper_names:
+                    if pen[18] == network:
+                        pen[2] += f' <hypernet:{pen[18]}:0.85>'
+                for network in settings.global_var.lora_names:
+                    if pen[18] == network:
+                        pen[2] += f' <lora:{pen[18]}:0.85>'
             # set batch to 1
             pen[13] = [1, 1]
 
@@ -256,7 +259,7 @@ class DrawModal(Modal):
                 prompt_output += f'\nNew model: ``{new_model}``'
             index_start = 5
             for index, value in enumerate(tuple_names[index_start:], index_start):
-                if index == 13 or index == 17:
+                if index == 13 or index == 16:
                     continue
                 if str(pen[index]) != str(self.input_tuple[index]):
                     prompt_output += f'\nNew {value}: ``{pen[index]}``'

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -255,6 +255,8 @@ class DrawModal(Modal):
             # figure out what extra_net was used
             if pen[18] != 'None':
                 pen[2], pen[18], new_net_multi = settings.extra_net_check(pen[2], pen[18], net_multi)
+            channel = '% s' % pen[0].channel.id
+            pen[2] = settings.extra_net_defaults(pen[2], channel)
             # set batch to 1
             pen[13] = [1, 1]
 

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -27,12 +27,11 @@ input_tuple[0] = ctx
 [15] = facefix
 [16] = highres_fix
 [17] = clip_skip
-[18] = hypernet
-[19] = lora
+[18] = extra_net
 '''
 tuple_names = ['ctx', 'simple_prompt', 'prompt', 'negative_prompt', 'data_model', 'steps', 'width', 'height',
                'guidance_scale', 'sampler', 'seed', 'strength', 'init_image', 'batch', 'styles', 'facefix',
-               'highres_fix', 'clip_skip', 'hypernet', 'lora']
+               'highres_fix', 'clip_skip', 'extra_net']
 
 
 # the modal that is used for the 🖋 button
@@ -207,22 +206,13 @@ class DrawModal(Modal):
                     invalid_input = True
                     embed_err.add_field(name=f"`{line.split(':', 1)[1]}` is too much CLIP to skip!",
                                         value='The range is from `1` to `12`.', inline=False)
-            if 'hypernet:' in line:
-                if line.split(':', 1)[1] in settings.global_var.hyper_names:
+            if 'extra_net:' in line:
+                if line.split(':', 1)[1] in settings.global_var.extra_nets:
                     pen[18] = line.split(':', 1)[1]
                 else:
                     invalid_input = True
-                    embed_err.add_field(name=f"`{line.split(':', 1)[1]}` isn't one of these hypernetworks!",
-                                        value=', '.join(['`%s`' % x for x in settings.global_var.hyper_names]),
-                                        inline=False)
-
-            if 'lora:' in line:
-                if line.split(':', 1)[1] in settings.global_var.lora_names:
-                    pen[19] = line.split(':', 1)[1]
-                else:
-                    invalid_input = True
-                    embed_err.add_field(name=f"`{line.split(':', 1)[1]}` can't be found! Try one of these LoRA.",
-                                        value=', '.join(['`%s`' % x for x in settings.global_var.lora_names]),
+                    embed_err.add_field(name=f"`{line.split(':', 1)[1]}` isn't one of these extra networks!",
+                                        value=', '.join(['`%s`' % x for x in settings.global_var.extra_nets]),
                                         inline=False)
 
         # stop and give a useful message if any extended edit values aren't recognized


### PR DESCRIPTION
This PR combines /draw's **hypernet** and **lora** into **extra_net**.  

Why would I do this?  
- There are too many options for /draw (18 options); I'd like to slim down what I can without removing functionality.
- It seems to me that people aren't really using hypernet as much as before, and most are moving to LoRa.
- Both hypernet and LoRA are kinda the same thing to my eyes lol.

To not affect any existing channel defaults, this PR doesn't change /settings, so bot hosts can still independently set default hypernet and LoRA.

/info will still have separate hypernet and LoRA buttons. I add a note on both indicating that they can be found in **extra_net**.

The placement of **extra_net** is moved up 3 spots; now between **styles** and **facefix**. I feel like I could move it up higher but idunno.. 

The **extra_net** lists all hypernet, then all LoRA.

what's done:
- Everything mentioned above.
- AIYA able to identify between hypernet and LoRA and append the respective type into the prompt.
- 🖋️'s "extended edit" updated to show **extra_net**.

to do:
- ~~Update 🖋️ error message to account for Discord embed limits (1024 characters limit).~~ ✅ call the lists from /info
- ~~See if I can add ability to set multiplier when using **extra_net**.~~ ✅
- ~~make sure channel default hypernet and loras still applied after using 🖋️~~ ✅
- add ability to set multiplier to hypernet/lora in /settings