### PR TITLE
Added check to global_var.lora_names before removing empty string

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -571,7 +571,8 @@ def populate_global_vars():
         global_var.facefix_models.insert(0, 'None')
     if 'None' not in global_var.hyper_names:
         global_var.hyper_names.insert(0, 'None')
-    global_var.lora_names.remove('')
+    if '' in global_var.lora_names:
+        global_var.lora_names.remove('')
     global_var.extra_nets = global_var.hyper_names + global_var.lora_names
     global_var.lora_names.insert(0, 'None')
     global_var.hires_upscaler_names.insert(0, 'Disabled')


### PR DESCRIPTION
I encountered this bug when running this on my machine, below is the stack trace:

```
Traceback (most recent call last):
  File "/home/joelricker/sourceBuilds/aiyabot/aiya.py", line 22, in <module>
    settings.files_check()
  File "/home/joelricker/sourceBuilds/aiyabot/core/settings.py", line 469, in files_check
    populate_global_vars()
  File "/home/joelricker/sourceBuilds/aiyabot/core/settings.py", line 574, in populate_global_vars
    global_var.lora_names.remove('')
ValueError: list.remove(x): x not in list
```

With my set-up, it looks like the SD API was not sending an empty string in the lora_names configuration list. Because the bot settings script expects it, it falls over on the `global_var.lora_names.remove('')` if the empty string is not returned in the list from the API. Adding the check ensures that it works for both set-ups.

After adding the check, the bot worked like a charm.