### PR TITLE
Added support for image grids

### DIFF
--- a/core/ctxmenuhandler.py
+++ b/core/ctxmenuhandler.py
@@ -40,8 +40,9 @@ def style_remove(search, field):
     return field.strip(',')
 
 
-async def parse_image_info(ctx, image_url, command):
+async def parse_image_info(ctx, image_urls, command, index=0):
     message = ''
+    image_url = image_urls[index]
     try:
         # construct a payload
         image = base64.b64encode(requests.get(image_url, stream=True).content).decode('utf-8')
@@ -196,7 +197,15 @@ async def parse_image_info(ctx, image_url, command):
         if command == 'button':
             return embed
 
-        await ctx.respond(embed=embed, ephemeral=True)
+        input_tuple = (None, image_urls, index)
+        view = viewhandler.IdentifyView(input_tuple)
+
+        if len(image_urls)==1:
+            view = None
+        else:
+            embed.title += " (1/"+str(len(image_urls))+")"
+
+        await ctx.respond(embed=embed, view=view, ephemeral=True)
     except Exception as e:
         print('The image info command broke: ' + str(e))
         if command == 'slash':
@@ -218,8 +227,7 @@ async def get_image_info(ctx, message: discord.Message):
         await ctx.respond(content="No images were found in the message...", ephemeral=True)
         return
 
-    for image_url in urls:
-        await parse_image_info(ctx, image_url, "context")
+    await parse_image_info(ctx, urls, "context")
 
 
 async def quick_upscale(self, ctx, message: discord.Message):

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -130,7 +130,7 @@ class IdentifyCog(commands.Cog):
 
                 queuehandler.process_post(
                     self, queuehandler.PostObject(
-                        self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>', file='', embed=embed, view=queue_object.view))
+                        self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>', file='', files=None, embed=embed, view=queue_object.view))
             Thread(target=post_dream, daemon=True).start()
 
         except Exception as e:

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -68,7 +68,7 @@ class IdentifyCog(commands.Cog):
         elif phrasing == 'Tags':
             phrasing = 'deepdanbooru'
         else:
-            await ctxmenuhandler.parse_image_info(ctx, init_image.url, "slash")
+            await ctxmenuhandler.parse_image_info(None, [init_image.url], "slash")
             return
 
         # set up tuple of parameters to pass into the Discord view

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -59,11 +59,12 @@ class IdentifyObject:
 
 # the queue object for posting to Discord
 class PostObject:
-    def __init__(self, cog, ctx, content, file, embed, view):
+    def __init__(self, cog, ctx, content, file, files, embed, view):
         self.cog = cog
         self.ctx = ctx
         self.content = content
         self.file = file
+        self.files = files
         self.embed = embed
         self.view = view
 

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -449,16 +449,9 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                 draw_time = '{0:.3f}'.format(end_time - start_time)
                 message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
 
-                view = queue_object.view
-                if count == 1:
+                if count == 0:
                     content = f'<@{queue_object.ctx.author.id}>, {message}'
-                # only enable buttons on last image in batch
-                if len(image_data) > 1:
-                    if count == 1:
-                        content = f'<@{queue_object.ctx.author.id}>, {message}\n' \
-                                  f'*Please use the context menu for drawings without buttons.*'
-                    if count != len(image_data):
-                        view = None
+
                 for j in range(9):
                     count += 1
 
@@ -518,9 +511,18 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                         files.append(file)
 
                     i += 1
+
+                view = queue_object.view
+                # only enable buttons on last image in batch
+                if len(image_data) > 1:
+                    if count == 1:
+                        content = f'<@{queue_object.ctx.author.id}>, {message}\n' \
+                                  f'*Please use the context menu for drawings without buttons.*'
+                    if count != len(image_data):
+                        view = None
                 queuehandler.process_post(
                     self, queuehandler.PostObject(
-                        self, queue_object.ctx, content=content, files=files, embed='', view=view))
+                        self, queue_object.ctx, content=content, file=None, files=files, embed='', view=view))
                 # increment seed for view when using batch
                 if count != len(image_data):
                     batch_seed = list(queue_object.view.input_tuple)

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -218,7 +218,7 @@ class UpscaleCog(commands.Cog):
 
                     queuehandler.process_post(
                         self, queuehandler.PostObject(
-                            self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>, {message}', file=file, embed='', view=queue_object.view))
+                            self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>, {message}', file=file, files=None, embed='', view=queue_object.view))
             Thread(target=post_dream, daemon=True).start()
 
         except Exception as e:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -462,8 +462,7 @@ class IdentifyView(View):
                 button.disabled = self.input_tuple[2]-1 < 0
                 self.children[1].disabled = self.input_tuple[2]+1 >= len(self.input_tuple[1])
                 await interaction.response.edit_message(embed=embed, view=self)
-        except(Exception,) as exc:
-            print(exc)
+        except(Exception,):
             await interaction.response.edit_message(view=None)
             await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
 
@@ -479,7 +478,6 @@ class IdentifyView(View):
                 button.disabled = self.input_tuple[2]+1 >= len(self.input_tuple[1])
                 self.children[0].disabled = self.input_tuple[2]-1 < 0
                 await interaction.response.edit_message(embed=embed, view=self)
-        except(Exception,) as exc:
-            print(exc)
+        except(Exception,):
             await interaction.response.edit_message(view=None)
             await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -389,10 +389,12 @@ class DrawView(View):
         # reuse "read image info" command from ctxmenuhandler
         init_url = None
         try:
-            attachment = self.message.attachments[0]
+            attachments = []
+            for attachment in self.message.attachments:
+                attachments.append(attachment.url)
             if self.input_tuple[12]:
                 init_url = self.input_tuple[12].url
-            embed = await ctxmenuhandler.parse_image_info(init_url, attachment.url, "button")
+            embed = await ctxmenuhandler.parse_image_info(init_url, attachments, "button")
             await interaction.response.send_message(embed=embed, ephemeral=True)
         except Exception as e:
             print('The clipboard button broke: ' + str(e))
@@ -441,3 +443,43 @@ class DeleteView(View):
             await interaction.response.edit_message(view=self)
             await interaction.followup.send("I may have been restarted. This button no longer works.\n"
                                             "You can react with ❌ to delete the image.", ephemeral=True)
+
+class IdentifyView(View):
+    def __init__(self, input_tuple):
+        super().__init__(timeout=None)
+        self.input_tuple = input_tuple
+
+    @discord.ui.button(
+        custom_id="button_prev",
+        emoji="◀️",
+        disabled=True)
+    async def prev(self, button, interaction):
+        try:
+            if self.input_tuple[2]-1 >= 0:
+                self.input_tuple = (self.input_tuple[0],self.input_tuple[1],self.input_tuple[2]-1)
+                embed = await ctxmenuhandler.parse_image_info(self.input_tuple[0], self.input_tuple[1], 'button', self.input_tuple[2])
+                embed.title+=" ("+str(self.input_tuple[2]+1)+"/"+str(len(self.input_tuple[1]))+")"
+                button.disabled = self.input_tuple[2]-1 < 0
+                self.children[1].disabled = self.input_tuple[2]+1 >= len(self.input_tuple[1])
+                await interaction.response.edit_message(embed=embed, view=self)
+        except(Exception,) as exc:
+            print(exc)
+            await interaction.response.edit_message(view=None)
+            await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)
+
+    @discord.ui.button(
+        custom_id="button_next",
+        emoji="▶️")
+    async def next(self, button, interaction):
+        try:
+            if self.input_tuple[2]+1 < len(self.input_tuple[1]):
+                self.input_tuple = (self.input_tuple[0],self.input_tuple[1],self.input_tuple[2]+1)
+                embed = await ctxmenuhandler.parse_image_info(self.input_tuple[0], self.input_tuple[1], 'button', self.input_tuple[2])
+                embed.title+=" ("+str(self.input_tuple[2]+1)+"/"+str(len(self.input_tuple[1]))+")"
+                button.disabled = self.input_tuple[2]+1 >= len(self.input_tuple[1])
+                self.children[0].disabled = self.input_tuple[2]-1 < 0
+                await interaction.response.edit_message(embed=embed, view=self)
+        except(Exception,) as exc:
+            print(exc)
+            await interaction.response.edit_message(view=None)
+            await interaction.followup.send("I may have been restarted. This button no longer works.", ephemeral=True)


### PR DESCRIPTION
I don't normally work with Python, so I apologize in advance for any messy code that needs a few revisions still.

This changes so that the bot will post up to 9 images as attachments to each message, looking like the following:

![chrome_4vocy1DWrJ](https://user-images.githubusercontent.com/1905293/235057706-4ffd6cb5-1f7d-4188-9047-90ab9895f24a.png)

![chrome_UuHz0RbnsJ](https://user-images.githubusercontent.com/1905293/235057712-0dff403b-5a0d-4522-a368-6196e3fdde9c.png)

This also updates the Get Image Info command to not post as many messages as there are attachments to a message, instead you use a view to change which page you are on, the buttons will automatically be disabled at either end of the number of images on said message.

![chrome_mzHLyYk5LZ](https://user-images.githubusercontent.com/1905293/235059248-af203e89-272f-4ca1-9839-37e12b712e16.gif)
