### PR TITLE
Added paging to image info

### DIFF
--- a/core/ctxmenuhandler.py
+++ b/core/ctxmenuhandler.py
@@ -40,8 +40,9 @@ def style_remove(search, field):
     return field.strip(',')
 
 
-async def parse_image_info(ctx, image_url, command):
+async def parse_image_info(ctx, image_urls, command, index=0):
     message = ''
+    image_url = image_urls[index]
     try:
         # construct a payload
         image = base64.b64encode(requests.get(image_url, stream=True).content).decode('utf-8')
@@ -196,7 +197,15 @@ async def parse_image_info(ctx, image_url, command):
         if command == 'button':
             return embed
 
-        await ctx.respond(embed=embed, ephemeral=True)
+        input_tuple = (None, image_urls, index)
+        view = viewhandler.IdentifyView(input_tuple)
+
+        if len(image_urls)==1:
+            view = None
+        else:
+            embed.title += " (1/"+str(len(image_urls))+")"
+
+        await ctx.respond(embed=embed, view=view, ephemeral=True)
     except Exception as e:
         print('The image info command broke: ' + str(e))
         if command == 'slash':
@@ -218,8 +227,7 @@ async def get_image_info(ctx, message: discord.Message):
         await ctx.respond(content="No images were found in the message...", ephemeral=True)
         return
 
-    for image_url in urls:
-        await parse_image_info(ctx, image_url, "context")
+    await parse_image_info(ctx, urls, "context")
 
 
 async def quick_upscale(self, ctx, message: discord.Message):

--- a/core/identifycog.py
+++ b/core/identifycog.py
@@ -68,7 +68,7 @@ class IdentifyCog(commands.Cog):
         elif phrasing == 'Tags':
             phrasing = 'deepdanbooru'
         else:
-            await ctxmenuhandler.parse_image_info(ctx, init_image.url, "slash")
+            await ctxmenuhandler.parse_image_info(ctx, [init_image.url], "slash")
             return
 
         # set up tuple of parameters to pass into the Discord view


### PR DESCRIPTION
This is a reduced version of a different PR I made #176; however after reading the plans to embed a single image that contains a grid of up to 25 images, I ended up scrapping most of the changes I had made in that earlier PR. 

I will note that I don't have much experience using Python, so I apologize for any weird methods I used to make my changes.

This PR adds paging to the ctxmenuhandler.parse_image_info embed by allowing a list of images instead of a single image. I felt it might still be useful, but I don't know quite what the plan was for image info once the move to 25 image grids occurred. The PR originally was based around how I implemented 3x3 grids for images by just attaching multiple files, as it made so I didn't receive 9 messages in a row all regarding how to remake individual items when I used the context menu. 

![chrome_mzHLyYk5LZ](https://user-images.githubusercontent.com/1905293/235067114-3b8d2dbf-71ce-4c0f-abe5-3cd92185ba92.gif)
