### PR TITLE
Change in auth checker

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -319,8 +319,7 @@ def authenticate_user():
     # do a check to see if --gradio-auth is set
     if global_var.gradio_auth is None:
         r = s.get(global_var.url + '/sdapi/v1/cmd-flags')
-        response_data = r.json()
-        if response_data['gradio_auth']:
+        if r.status_code == 401:
             global_var.gradio_auth = True
         else:
             global_var.gradio_auth = False


### PR DESCRIPTION
This way we check the status 401 "Not authenticated", instead of gradio_auth. Helpful to work with other forks of a1111 Tested and works perfect on original [a1111 ](https://github.com/AUTOMATIC1111/stable-diffusion-webui) and [it's best fork](https://github.com/vladmandic/automatic)