### PR TITLE
Add /Generate queue + thread + /Queue slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ To generate an image from text, use the /draw command and include your prompt as
 
 <img src=https://raw.githubusercontent.com/Kilvoctu/kilvoctu.github.io/master/pics/preview2.png>
 
+To generate a prompt from a couple of words, use the /generate command and include your text as the query.
+
+![image](https://github.com/wizz13150/aiyabot/assets/22177081/20c34f36-1b7d-412b-8e53-4e4b25562167)
+
+
 ### Currently supported options
 
 - negative prompts
@@ -36,6 +41,7 @@ To generate an image from text, use the /draw command and include your prompt as
 - /identify command - create a caption for your image.
 - /generate command - generate a prompt from text, using https://huggingface.co/Gustavosta/MagicPrompt-Stable-Diffusion
 - /stats command - shows how many /draw commands have been used.
+- /queue command - shows the size of each queue.
 - /info command - basic usage guide, other info, and download batch images.
 - /upscale command - resize your image.
 - buttons - certain outputs will contain buttons.

--- a/aiya.py
+++ b/aiya.py
@@ -6,6 +6,8 @@ from core import ctxmenuhandler
 from core import settings
 from core.logging import get_logger
 from dotenv import load_dotenv
+from core.queuehandler import GlobalQueue
+
 
 # start up initialization stuff
 self = discord.Bot()
@@ -35,6 +37,14 @@ async def stats(ctx):
                           color=settings.global_var.embed_color)
     await ctx.respond(embed=embed)
 
+# queue slash command
+@self.slash_command(name='queue', description='Check the size of each queue')
+async def queue(ctx):
+    queue_sizes = GlobalQueue.get_queue_sizes()
+    description = '\n'.join([f'{name}: {size}' for name, size in queue_sizes.items()])
+    embed = discord.Embed(title='Queue Sizes', description=description, 
+                          color=settings.global_var.embed_color)
+    await ctx.respond(embed=embed)
 
 # context menu commands
 @self.message_command(name="Get Image Info")

--- a/core/generatecog.py
+++ b/core/generatecog.py
@@ -31,12 +31,12 @@ class GenerateCog(commands.Cog):
                             prompt: Optional[str]):
 
         # set up the queue
-        if queuehandler.GlobalQueue.dream_thread.is_alive():
-            queuehandler.GlobalQueue.queue.append(queuehandler.GenerateObject(self, ctx, prompt))
+        if queuehandler.GlobalQueue.generate_thread.is_alive():
+            queuehandler.GlobalQueue.generate_queue.append(queuehandler.GenerateObject(self, ctx, prompt))
         else:
-            await queuehandler.process_dream(self, queuehandler.GenerateObject(self, ctx, prompt))
-        
-        await ctx.send_response(f"<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}`` - Your text: ``{prompt}``")
+            await queuehandler.process_generate(self, queuehandler.GenerateObject(self, ctx, prompt))
+
+        await ctx.send_response(f"<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.generate_queue)}`` - Your text: ``{prompt}``")
 
     def post(self, event_loop: AbstractEventLoop, post_queue_object: queuehandler.PostObject):
         event_loop.create_task(
@@ -68,7 +68,9 @@ class GenerateCog(commands.Cog):
             event_loop.create_task(queue_object.ctx.channel.send(embed=embed))
 
         # check each queue for any remaining tasks
-        queuehandler.process_queue()
+        if queuehandler.GlobalQueue.generate_queue:
+            event_loop.create_task(queuehandler.process_generate(self, queuehandler.GlobalQueue.generate_queue.pop(0)))
+
 
 def setup(bot):
     bot.add_cog(GenerateCog(bot))

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -81,11 +81,20 @@ class PostObject:
 class GlobalQueue:
     dream_thread = Thread()
     post_event_loop = asyncio.get_event_loop()
-    queue: list[DrawObject | UpscaleObject | IdentifyObject | GenerateObject] = []
-
+    queue: list[DrawObject | UpscaleObject | IdentifyObject] = []
+    # new generate queue and thread
+    generate_queue: list[GenerateObject] = []
+    generate_thread = Thread()
+    
     post_thread = Thread()
     event_loop = asyncio.get_event_loop()
     post_queue: list[PostObject] = []
+    
+    def get_queue_sizes():
+        return {
+            "General Queue": len(GlobalQueue.queue),
+            "/Generate Queue": len(GlobalQueue.generate_queue)
+        }
 
 
 def process_queue():
@@ -97,10 +106,13 @@ def process_queue():
         start(GlobalQueue.queue)
 
 
-async def process_dream(self, queue_object: DrawObject | UpscaleObject | IdentifyObject | GenerateObject):
+async def process_dream(self, queue_object: DrawObject | UpscaleObject | IdentifyObject):
     GlobalQueue.dream_thread = Thread(target=self.dream, args=(GlobalQueue.event_loop, queue_object))
     GlobalQueue.dream_thread.start()
 
+async def process_generate(self, queue_object: GenerateObject):
+    GlobalQueue.generate_thread = Thread(target=self.dream, args=(GlobalQueue.event_loop, queue_object))
+    GlobalQueue.generate_thread.start()
 
 def process_post(self, queue_object: PostObject):
     if GlobalQueue.post_thread.is_alive():


### PR DESCRIPTION
Hey, 

'Lil fix of my previous approach for a dedicated queue for /Generate, on a new different thread. 
Cause /Generate is running on a different model, on the cpu, shouldn't wait.
Text generation is pretty fast, but the bot can be on many servers.

Add the /Queue slash command to see both queue lenght. Would say another useless command, but pretty intuitive, so seems okay to me.

+Change of the readme

Screen : 

![image](https://github.com/Kilvoctu/aiyabot/assets/22177081/e9290bb7-8fcc-4bb6-989e-c9be497429f8)

Didn't see any issue or error with this. Seems to work fine.