### PR TITLE
Updated maximum size and minimum generation size to accommodate SDXL generation sizes.

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -45,7 +45,7 @@ batch_buttons = "False"
 restrict_buttons = "True"
 
 # The maximum value allowed for width/height (keep as multiple of 64)
-max_size = 1024
+max_size = 2048
 
 # The resize amount when using context menu Quick Upscale
 quick_upscale_resize = 2.0
@@ -99,7 +99,7 @@ class GlobalVar:
     api_user: Optional[str] = None
     api_pass: Optional[str] = None
     model_info = {}
-    size_range = range(192, 1088, 64)
+    size_range = range(512, 2112, 64)
     size_range_exceed = None
     sampler_names = []
     style_names = {}
@@ -493,7 +493,7 @@ def populate_global_vars():
     global_var.display_ignored_words = config['display_ignored_words']
     global_var.negative_prompt_prefix = [x for x in config['negative_prompt_prefix']]
     # slash command doesn't update this dynamically. Changes to size need a restart.
-    global_var.size_range = range(192, config['max_size'] + 64, 64)
+    global_var.size_range = range(512, config['max_size'] + 64, 64)
     if len(global_var.size_range) > 25:
         global_var.size_range_exceed = [x for x in global_var.size_range]
         global_var.size_range = []


### PR DESCRIPTION
Seeing as SDXL models have been out for a while now, I was surprised to see this project doesn't support it's most common generation sizes.

My changes bring the minimum generation size to 512 and the maximum to 2048. I know 2048 is overkill but call it future-proofing. **These new slash-command options do not exceed Discord's limit of 25 previewed options.** My changes also hit all of the recommended SDXL generation sizes.

Stabililty AI has stated that the following generation sizes are ideal for SDXL models:
- 1024 x 1024
- 1152 x 896
- 896 x 1152
- 1216 x 832
- 832 x 1216
- 1344 x 768
- 1536 x 640
- 640 x 1536

My solution hits all of these and more without changing the 64 increment rule already instated.