### PR TITLE
Docker improvements and optional commands

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.env
+resources/*.json
+resources/config.toml
+resources/models.csv
+resources/stats.txt
+outputs
+!outputs/.keep
+.idea
+venv
+venvnew
+core/MagicPrompt-SD
+.github

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Note the following environment variables work with the docker image:
 - `APIPASS` - API password if required for your Web UI instance.
 - `USER` - Username if required for your Web UI instance.
 - `PASS` - Password if required for your Web UI instance.
+- `USE_GENERATE` - Set whether the `/generate` command is enabled as well as if required package (`torch nvidia transformers`) are installed
 
 ### Docker compose
 
@@ -109,7 +110,7 @@ Note the following environment variables work with the docker image:
 - Ensure AIYA has `bot` and `application.commands` scopes when inviting to your Discord server, and intents are enabled.
 - As /settings can be abused, consider reviewing who can access the command. This can be done through Apps -> Integrations in your Server Settings. Read more about /settings [here.](https://github.com/Kilvoctu/aiyabot/wiki/settings-command)
 - AIYA uses Web UI's legacy high-res fix method. To ensure this works correctly, in your Web UI settings, enable this option: `For hires fix, use width/height sliders to set final resolution rather than first pass`
-
+- For systems with less memory/cpu, or if the `/generate` command is not needed, it can be disabled by setting the environmental variable `USE_GENERATE=false` for docker/cli.
 
 ## Credits
 

--- a/aiya.py
+++ b/aiya.py
@@ -26,7 +26,14 @@ self.load_extension('core.stablecog')
 self.load_extension('core.upscalecog')
 self.load_extension('core.identifycog')
 self.load_extension('core.infocog')
-self.load_extension('core.generatecog')
+
+use_generate = os.getenv("USE_GENERATE", 'True')
+enable_generate = use_generate.lower() in ('true', '1', 't')
+if enable_generate:
+    print(f"/generate command is ENABLED due to USE_GENERATE={use_generate}")
+    self.load_extension('core.generatecog')
+else:
+    print(f"/generate command is DISABLED due to USE_GENERATE={use_generate}")
 
 # stats slash command
 @self.slash_command(name='stats', description='How many images have I generated?')

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,16 @@ if python -m pip show -q py-cord ; then
 else
   printf '****************\nInstalling requirements, this may take some time!\n****************\n'
 fi
-pip install -r requirements.txt
+
+USE_GEN="${USE_GENERATE:=true}"
+
+if [ "$USE_GEN" = "true" ]; then
+  pip install -r requirements.txt
+else
+  pip install -r requirements_no_generate.txt
+fi
+
+#pip install -r requirements.txt
 
 printf '****************\nRequirements satisfied!\n****************\n'
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eou pipefail
 
+USE_GEN="${USE_GENERATE:=true}"
+
 # requirements are installed at runtime instead of during image build
 # so that image isn't 6GB+ due to nvidia/torch package sizes
 #
@@ -11,15 +13,12 @@ else
   printf '****************\nInstalling requirements, this may take some time!\n****************\n'
 fi
 
-USE_GEN="${USE_GENERATE:=true}"
-
 if [ "$USE_GEN" = "true" ]; then
   pip install -r requirements.txt
 else
+  # don't use full requirements if user explicitly disabled /generate command
   pip install -r requirements_no_generate.txt
 fi
-
-#pip install -r requirements.txt
 
 printf '****************\nRequirements satisfied!\n****************\n'
 
@@ -27,9 +26,11 @@ printf '****************\nRequirements satisfied!\n****************\n'
 cp -n "/default/resources/messages.csv" "/app/resources/messages.csv"
 cp -n "/default/outputs/.keep" "/app/outputs/.keep"
 
-printf '****************\nChecking for required /generate files/models\n****************\n'
-# Download generate pre-reqs
-python core/setup_generate.py
+if [ "$USE_GEN" = "true" ]; then
+  printf '****************\nChecking for required /generate files/models\n****************\n'
+  # Download generate pre-reqs
+  python core/setup_generate.py
+fi
 
 printf '****************\nStarting Aiyabot\n****************\n'
 # Start the app.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,27 @@
 #!/bin/bash
 set -eou pipefail
 
+# requirements are installed at runtime instead of during image build
+# so that image isn't 6GB+ due to nvidia/torch package sizes
+#
+# will cause first run to take a long time but subsequent container starts will be fast
+if python -m pip show -q py-cord ; then
+  printf '****************\nChecking requirements\n****************\n'
+else
+  printf '****************\nInstalling requirements, this may take some time!\n****************\n'
+fi
+pip install -r requirements.txt
+
+printf '****************\nRequirements satisfied!\n****************\n'
+
 # Copy the default resource and outputs files if they don't exist.
 cp -n "/default/resources/messages.csv" "/app/resources/messages.csv"
 cp -n "/default/outputs/.keep" "/app/outputs/.keep"
 
+printf '****************\nChecking for required /generate files/models\n****************\n'
 # Download generate pre-reqs
 python core/setup_generate.py
+
+printf '****************\nStarting Aiyabot\n****************\n'
 # Start the app.
 python aiya.py

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.11
 
 ENV TOKEN="" \
 	URL="http://127.0.0.1:7860" \

--- a/dockerfile
+++ b/dockerfile
@@ -10,9 +10,8 @@ ENV TOKEN="" \
 
 WORKDIR /app
 
-# Install dependencies
+# Copy requirements
 COPY ./requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
 
 # Pull in the source code
 COPY ./resources /default/resources

--- a/dockerfile
+++ b/dockerfile
@@ -20,5 +20,7 @@ COPY . /app
 
 RUN chmod +x /app/docker-entrypoint.sh
 
+ENV USE_GENERATE=true
+
 # Run the bot
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]

--- a/requirements_no_generate.txt
+++ b/requirements_no_generate.txt
@@ -1,0 +1,6 @@
+py-cord
+python-dotenv
+requests
+Pillow
+tomlkit
+urlextract


### PR DESCRIPTION
Makes the following changes:

## Fix python version

[Python fails when using 3.12](https://github.com/Kilvoctu/aiyabot/issues/240), downgrade to 3.11 to fix this.

## Move Requirements Installation to Runtime

The addition of `/generate` requires [`transformers` and `torch`](https://github.com/Kilvoctu/aiyabot/commit/15de106d662ed025c0a87465eb3fdcde8d9169c0) which adds 5GB+ to the `site-packages` directory due to models and other resources that need to be downloaded. This isn't an issue per se but it does mean that docker images are now 6GB+ instead of the previous ~360MB since requirements install is done during image build.

This PR moves requirements installation to `docker-entrypoint.sh` so that these packages are instead downloaded when the container first runs, making the image lightweight again. It also enables...

## Optional `/generate` inclusion

As the bot hoster, and a user, I don't personally need or use `/generate`. My users are perfectly happy with the prompts they generate organically! However I still have to incur the downloads, slower startup due to requirements install, and **10x increase in memory usage** for the application to load torch/transformers.

This PR adds the environmental variable `USE_GENERATE` as a string boolean (`true` or `false`). It defaults to `true` to maintain backward compatibility. Behavior:

* When `false` in `docker_entrypoint`
  *  Uses a variant `requirements_no_generate.txt` for `pip install`  to avoid downloading torch/transformers
  * Skips running `python core/setup_generate.py`
* When `false` at bot startup skips loading `generatecog`

Enabling me to use aiyabot without `/generate` and without the system requirements incurred by the needed packages.