### PR TITLE
feat: Implement compatibility with SD.Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To generate a prompt from a couple of words, use the /generate command and inclu
 - denoising strength
 - batch count
 - compatibility with [SD.Next](https://github.com/vladmandic/automatic)
+  - "Full quality" VAE toggle
 
 #### Bonus features
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To generate a prompt from a couple of words, use the /generate command and inclu
 - img2img
 - denoising strength
 - batch count
+- compatibility with [SD.Next](https://github.com/vladmandic/automatic)
 
 #### Bonus features
 
@@ -65,8 +66,9 @@ To generate a prompt from a couple of words, use the /generate command and inclu
 
 ## Setup requirements
 
-- Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
+- Set up [AUTOMATIC1111's Stable Diffusion AI Web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) OR [SD.Next](https://github.com/vladmandic/automatic)
   - AIYA is currently tested on commit `20ae71faa8ef035c31aa3a410b707d792c8203a3` of the Web UI.
+  - For SD.Next currently tested on master branch at [2024-03-01](https://github.com/vladmandic/automatic/blob/master/CHANGELOG.md#update-for-2024-03-01) (`325ed10a04775c49c36fc3308559507a4a82271b`)
 - Run the Web UI as local host with API (`COMMANDLINE_ARGS= --api`).
 - Clone this repo.
 - Create a file in your cloned repo called ".env", formatted like so:
@@ -121,6 +123,8 @@ Note the following environment variables work with the docker image:
 AIYA only exists thanks to these awesome people:
 - AUTOMATIC1111, and all the contributors to the Web UI repo.
   - https://github.com/AUTOMATIC1111/stable-diffusion-webui
+- vladmandic and all SD.Next contributors
+  - https://github.com/vladmandic/automatic
 - harubaru, my entryway into Stable Diffusion (with Waifu Diffusion) and foundation for the AIYA Discord bot.
   - https://github.com/harubaru/waifu-diffusion
   - https://github.com/harubaru/discord-stable-diffusion

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,0 +1,3 @@
+
+BACKEND_WEBUI = 'webui'
+BACKEND_SDNEXT = 'sdnext'

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -6,7 +6,7 @@ from threading import Thread
 class DrawObject:
     def __init__(self, cog, ctx, simple_prompt, prompt, negative_prompt, data_model, steps, width, height,
                  guidance_scale, sampler, seed, strength, init_image, batch, styles, facefix, highres_fix,
-                 clip_skip, extra_net, spoiler, epoch_time, view):
+                 clip_skip, extra_net, spoiler, epoch_time, full_quality_vae, view):
         self.cog = cog
         self.ctx = ctx
         self.simple_prompt = simple_prompt
@@ -29,6 +29,7 @@ class DrawObject:
         self.extra_net = extra_net
         self.spoiler = spoiler
         self.epoch_time = epoch_time
+        self.full_quality_vae = full_quality_vae
         self.view = view
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -86,6 +86,9 @@ upscaler_1 = "ESRGAN_4x"
 spoiler = false
 # role ID (not name)
 spoiler_role = ""
+
+### SD.Next specific settings ###
+full_quality_vae = true
 """
 
 # initialize global variables here
@@ -107,6 +110,7 @@ class GlobalVar:
     sampler_names = []
     style_names = {}
     facefix_models = []
+    full_quality_vae = True
     embeddings_1 = []
     embeddings_2 = []
     hyper_names = []
@@ -279,6 +283,7 @@ def generate_template(template_pop, config):
     template_pop['style'] = config['style']
     template_pop['facefix'] = config['facefix']
     template_pop['highres_fix'] = config['highres_fix']
+    template_pop['full_quality_vae'] = config['full_quality_vae']
     template_pop['clip_skip'] = config['clip_skip']
     template_pop['hypernet'] = config['hypernet']
     template_pop['hyper_multi'] = config['hyper_multi']

--- a/core/settings.py
+++ b/core/settings.py
@@ -573,6 +573,14 @@ def populate_global_vars():
         global_var.hyper_names.append(s5['name'])
     for s6 in r6.json():
         global_var.upscaler_names.append(s6['name'])
+
+    try:
+        r7 = s.get(global_var.url + "/sdapi/v1/loras")
+        for s7 in r7.json():
+            global_var.lora_names.append(s7['alias'])
+    except Exception as e:
+        print('Error fetching lora endpoint but this may be normal for older webui versions', str(e))
+
     if 'SwinIR_4x' in global_var.upscaler_names:
         template['upscaler_1'] = 'SwinIR_4x'
 
@@ -606,7 +614,8 @@ def populate_global_vars():
         for c in old_config['components']:
             try:
                 if c['props']:
-                    if c['props']['elem_id'] == 'setting_sd_lora':
+                    # maintaining compatibility with older webui versions
+                    if c['props']['elem_id'] == 'setting_sd_lora' and len(global_var.lora_names) == 0:
                         global_var.lora_names = c['props']['choices']
                     if c['props']['elem_id'] == 'txt2img_hr_upscaler':
                         global_var.hires_upscaler_names = c['props']['choices']

--- a/core/settings.py
+++ b/core/settings.py
@@ -358,15 +358,11 @@ def authenticate_user():
 
     # do a check to see if --gradio-auth is set
     if global_var.gradio_auth is None:
-        global_var.gradio_auth = False
-
         r = s.get(global_var.url + '/config')
-        response_data = r.json()
-        if global_var.backend == constants.BACKEND_WEBUI and response_data['gradio_auth']:
+        if r.status_code == 401:
             global_var.gradio_auth = True
-        # sdnext
-        elif global_var.backend == constants.BACKEND_SDNEXT and response_data['auth']:
-            global_var.gradio_auth = True
+        else:
+            global_var.gradio_auth = False
 
     if global_var.gradio_auth:
         login_payload = {

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -142,6 +142,12 @@ class SettingsCog(commands.Cog):
         choices=settings.global_var.facefix_models,
     )
     @option(
+        'full_quality_vae',
+        bool,
+        description='(SD.Next) Use full quality VAE to decode samples',
+        required=False,
+    )
+    @option(
         'highres_fix',
         str,
         description='Set default highres fix model for the channel',
@@ -216,6 +222,7 @@ class SettingsCog(commands.Cog):
                                hypernet: Optional[str] = None,
                                lora: Optional[str] = None,
                                facefix: Optional[str] = None,
+                               full_quality_vae: Optional[bool] = None,
                                highres_fix: Optional[str] = None,
                                clip_skip: Optional[int] = None,
                                strength: Optional[str] = None,
@@ -307,6 +314,11 @@ class SettingsCog(commands.Cog):
             height = settings.dimensions_validator(height)
             settings.update(channel, 'height', height)
             new += f'\nHeight: ``"{height}"``'
+            set_new = True
+
+        if full_quality_vae is not None:
+            settings.update(channel, 'full_quality_vae', full_quality_vae)
+            new += f'\nFull Quality VAE: ``"{full_quality_vae}"``'
             set_new = True
 
         if guidance_scale is not None:

--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -15,6 +15,7 @@ from core import queuehandler
 from core import viewhandler
 from core import settings
 from core import settingscog
+from . import constants
 
 
 class StableCog(commands.Cog, name='Stable Diffusion', description='Create images from natural language.'):
@@ -114,6 +115,12 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
         autocomplete=discord.utils.basic_autocomplete(settingscog.SettingsCog.hires_autocomplete),
     )
     @option(
+        'full_quality_vae',
+        bool,
+        description='(SD.Next) Use full quality VAE to decode samples',
+        required=False,
+    )
+    @option(
         'clip_skip',
         int,
         description='Number of last layers of CLIP model to skip.',
@@ -161,6 +168,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             extra_net: Optional[str] = None,
                             facefix: Optional[str] = None,
                             highres_fix: Optional[str] = None,
+                            full_quality_vae: Optional[str] = None,
                             clip_skip: Optional[int] = None,
                             strength: Optional[str] = None,
                             init_image: Optional[discord.Attachment] = None,
@@ -189,6 +197,8 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             facefix = settings.read(channel)['facefix']
         if highres_fix is None:
             highres_fix = settings.read(channel)['highres_fix']
+        if full_quality_vae is None:
+            full_quality_vae = settings.read(channel)['full_quality_vae']
         if clip_skip is None:
             clip_skip = settings.read(channel)['clip_skip']
         if strength is None:
@@ -340,14 +350,17 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
             bool_emoji = ':white_check_mark:' if derived_spoiler else ':negative_squared_cross_mark:'
             reply_adds += f'\nSpoiler: {bool_emoji}'
 
+
+        if full_quality_vae != settings.read(channel)['full_quality_vae']:
+            reply_adds += f'\nUse VAE: ``{full_quality_vae}``'
+
         epoch_time = int(time.time())
 
         # set up tuple of parameters to pass into the Discord view
         input_tuple = (
             ctx, simple_prompt, prompt, negative_prompt, data_model, steps, width, height, guidance_scale, sampler,
             seed, strength,
-            init_image, batch, styles, facefix, highres_fix, clip_skip, extra_net, derived_spoiler, epoch_time)
-
+            init_image, batch, styles, facefix, highres_fix, clip_skip, extra_net, derived_spoiler, epoch_time, full_quality_vae)
         view = viewhandler.DrawView(input_tuple)
         # setup the queue
         user_queue_limit = settings.queue_check(ctx.author)
@@ -404,6 +417,9 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     queue_object.styles
                 ]
             }
+
+            if settings.global_var.backend == constants.BACKEND_SDNEXT:
+                payload['full_quality'] = queue_object.full_quality_vae
 
             # update payload if init_img or init_url is used
             if queue_object.init_image is not None:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -34,10 +34,11 @@ input_tuple[0] = ctx
 [18] = extra_net
 [19] = spoiler
 [20] = epoch_time
+[21] = full_quality_vae
 '''
 tuple_names = ['ctx', 'simple_prompt', 'prompt', 'negative_prompt', 'data_model', 'steps', 'width', 'height',
                'guidance_scale', 'sampler', 'seed', 'strength', 'init_image', 'batch', 'styles', 'facefix',
-               'highres_fix', 'clip_skip', 'extra_net', 'spoiler', 'epoch_time']
+               'highres_fix', 'clip_skip', 'extra_net', 'spoiler', 'epoch_time', 'full_quality_vae']
 
 
 # the modal that is used for the 🖋 button


### PR DESCRIPTION
Originally based on https://github.com/hdtv35/aiyabot but with my own modifications so both backends can work

* Adds a `backend` global var and constants for setting the backend type
* backend is determined by endpoint GET at startup
* auth and model names are backend-dependent

~~This PR is **NOT** ready yet.~~ There are several SD.Next specific features in my own branch I want to pull in. But I wanted to get it out in the open in case anyone else using [SD.Next](https://github.com/vladmandic/automatic) wanted to give it a try and provide feedback.