### PR TITLE
fix who is @'d when using buttons

### DIFF
--- a/core/stablecog.py
+++ b/core/stablecog.py
@@ -539,7 +539,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                     queue_object.view.input_tuple = new_tuple
 
             # set up discord message
-            content = f'> for {queue_object.ctx.author.name}'
+            try:
+                user_id = queue_object.ctx.author.id
+            except(Exception,):
+                user_id = queue_object.ctx.user.id
             noun_descriptor = "drawing" if image_count == 1 else f'{image_count} drawings'
             draw_time = '{0:.3f}'.format(end_time - start_time)
             message = f'my {noun_descriptor} of ``{queue_object.simple_prompt}`` took me ``{draw_time}`` seconds!'
@@ -579,10 +582,10 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                         filename = f'SPOILER_{queue_object.seed}-{count}.png'
                     file = add_metadata_to_image(grid, images[current_grid * 25][2], filename)
                     if current_grid == 0:
-                        content = f'<@{queue_object.ctx.author.id}>, {message}\n ' \
+                        content = f'<@{user_id}>, {message}\n ' \
                                   f'Batch ID: {epoch_time}-{queue_object.seed}\n Image IDs: {id_start}-{id_end}'
                     else:
-                        content = f'> for {queue_object.ctx.author.name}, ' \
+                        content = f'> for {user_id}, ' \
                                   f'use /info or context menu to retrieve.\n ' \
                                   f'Batch ID: {epoch_time}-{queue_object.seed}\n Image IDs: {id_start}-{id_end}'
                         view = None
@@ -594,7 +597,7 @@ class StableCog(commands.Cog, name='Stable Diffusion', description='Create image
                             self, queue_object.ctx, content=content, file=file, embed='', view=view))
 
             else:
-                content = f'<@{queue_object.ctx.author.id}>, {message}'
+                content = f'<@{user_id}>, {message}'
                 filename = f'{queue_object.seed}-{count}.png'
                 if queue_object.spoiler:
                     filename = f'SPOILER_{queue_object.seed}-{count}.png'

--- a/core/upscalecog.py
+++ b/core/upscalecog.py
@@ -224,10 +224,14 @@ class UpscaleCog(commands.Cog):
                     draw_time = '{0:.3f}'.format(end_time - start_time)
                     message = f'my upscale of ``{queue_object.resize}``x took me ``{draw_time}`` seconds!'
                     file = discord.File(fp=buffer, filename=f'{self.file_name[0:120]}-{queue_object.resize}.png')
+                    try:
+                        user_id = queue_object.ctx.author.id
+                    except(Exception,):
+                        user_id = queue_object.ctx.user.id
 
                     queuehandler.process_post(
                         self, queuehandler.PostObject(
-                            self, queue_object.ctx, content=f'<@{queue_object.ctx.author.id}>, {message}', file=file, embed='', view=queue_object.view))
+                            self, queue_object.ctx, content=f'<@{user_id}>, {message}', file=file, embed='', view=queue_object.view))
             Thread(target=post_dream, daemon=True).start()
 
         except Exception as e:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -269,6 +269,7 @@ class DrawModal(Modal):
                 pen[13] = [1, 1]
 
             # the updated tuple to send to queue
+            pen[0] = interaction
             prompt_tuple = tuple(pen)
             draw_dream = stablecog.StableCog(self)
 
@@ -290,7 +291,7 @@ class DrawModal(Modal):
                 elif str(pen[18]) != str(self.input_tuple[18]):
                     prompt_output += f'\nNew extra network: ``{pen[18]}``'
 
-            print(f'Redraw -- {interaction.user.name}#{interaction.user.discriminator} -- Prompt: {pen[1]}')
+            print(f'Redraw -- {interaction.user.name} -- Prompt: {pen[1]}')
 
             # check queue again, but now we know user is not in queue
             if queuehandler.GlobalQueue.dream_thread.is_alive():
@@ -360,13 +361,14 @@ class DrawView(View):
             if buttons_free:
                 # update the tuple with a new seed
                 new_seed = list(self.input_tuple)
+                new_seed[0] = interaction
                 new_seed[10] = random.randint(0, 0xFFFFFFFF)
                 # set batch to 1
                 if settings.global_var.batch_buttons == "False":
                     new_seed[13] = [1, 1]
                 seed_tuple = tuple(new_seed)
 
-                print(f'Reroll -- {interaction.user.name}#{interaction.user.discriminator} -- Prompt: {seed_tuple[1]}')
+                print(f'Reroll -- {interaction.user.name} -- Prompt: {seed_tuple[1]}')
 
                 # set up the draw dream and do queue code again for lack of a more elegant solution
                 draw_dream = stablecog.StableCog(self)
@@ -411,13 +413,13 @@ class DrawView(View):
                     await interaction.response.send_message("Use the drop down menu to upscale batch images!", ephemeral=True)  # tell user to use dropdown for upscaling
                 else:
                     init_image = self.message.attachments[0]
-                    ctx = self.input_tuple[0]
+                    ctx = interaction
                     channel = '% s' % ctx.channel.id
                     settings.check(channel)
                     upscaler_1 = settings.read(channel)['upscaler_1']
                     upscale_tuple = (ctx, '2.0', init_image, upscaler_1, "None", '0.5', '0.0', '0.0', False)  # Create defaults for upscale. If desired we can add options to the per channel upscale settings for this.
 
-                    print(f'Upscaling -- {interaction.user.name}#{interaction.user.discriminator}')
+                    print(f'Upscaling -- {interaction.user.name}')
 
                     # set up the draw dream and do queue code again for lack of a more elegant solution
                     draw_dream = upscalecog.UpscaleCog(self)
@@ -568,7 +570,7 @@ class UpscaleMenu(discord.ui.Select):
                 upscaler_1 = settings.read(channel)['upscaler_1']
                 upscale_tuple = (ctx, '2.0', init_image, upscaler_1, "None", '0.5', '0.0', '0.0', False)  # Create defaults for upscale. If desired we can add options to the per channel upscale settings for this.
 
-                print(f'Upscaling -- {interaction.user.name}#{interaction.user.discriminator}')
+                print(f'Upscaling -- {interaction.user.name}')
 
                 # set up the draw dream and do queue code again for lack of a more elegant solution
                 draw_dream = upscalecog.UpscaleCog(self)


### PR DESCRIPTION
fixes #250

This bug occured as `restrict_buttons` was not in the initial scope for project; i.e., it was not intended for people to use buttons for other people's generations. So I overlooked it. 
Quick fix that should reference the user from `ctx` and fall back to `interaction` (because Discord wanted different syntax for some reason), which gets updated when using buttons.
This also removes user discriminator from console log, because those are no longer used by Discord.