### PR TITLE
Implement Live Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To generate a prompt from a couple of words, use the /generate command and inclu
 
 ### Currently supported options
 
+- live preview
 - negative prompts
 - swap model/checkpoint (_[see wiki](https://github.com/Kilvoctu/aiyabot/wiki/Model-swapping)_)
 - sampling steps
@@ -49,7 +50,8 @@ To generate a prompt from a couple of words, use the /generate command and inclu
   - 🎲 - randomize seed, then generate a new image with same parameters.
   - 📋 - view the generated image's information.
   - ⬆️ - upscale the generated image with defaults. Batch grids require use of the drop downs
-  - ❌ - deletes the generated image.
+  - ❌ - deletes the generated image. In Live preview this button interrupts generation process
+  - ➡️ - skips the current image generation in live preview and go to next batch (if there's more than 1)
 - dropdown menus - batch images produce two drop down menus for the first 25 images.
   - The first menu prompts the bot to send only the images that you select at single images
   - The second menu prompts the bot to upscale the selected image from the batch.

--- a/core/settings.py
+++ b/core/settings.py
@@ -59,6 +59,8 @@ prompt_ignore_list = []
 display_ignored_words = "False"
 # These words will be added to the beginning of the negative prompt
 negative_prompt_prefix = []
+# the time, in seconds, between when AIYA checks for generation progress from SD -- can be a float
+preview_update_interval = 3
 
 
 # the fallback channel defaults template for AIYA if nothing is set
@@ -125,6 +127,7 @@ class GlobalVar:
     negative_prompt_prefix = []
     spoiler = False
     spoiler_role = None
+    preview_update_interval = 3
 
 
 global_var = GlobalVar()
@@ -512,6 +515,8 @@ def populate_global_vars():
     global_var.prompt_ignore_list = [x for x in config['prompt_ignore_list']]
     global_var.display_ignored_words = config['display_ignored_words']
     global_var.negative_prompt_prefix = [x for x in config['negative_prompt_prefix']]
+    if config['preview_update_interval'] is not None:
+        global_var.preview_update_interval = float(config['preview_update_interval'])
 
     # create persistent session since we'll need to do a few API calls
     s = authenticate_user()

--- a/core/settings.py
+++ b/core/settings.py
@@ -60,7 +60,7 @@ display_ignored_words = "False"
 # These words will be added to the beginning of the negative prompt
 negative_prompt_prefix = []
 # the time, in seconds, between when AIYA checks for generation progress from SD -- can be a float
-preview_update_interval = 3
+live_preview_update_interval = 3
 
 
 # the fallback channel defaults template for AIYA if nothing is set
@@ -87,6 +87,7 @@ upscaler_1 = "ESRGAN_4x"
 spoiler = false
 # role ID (not name)
 spoiler_role = ""
+live_preview = true
 """
 
 
@@ -292,6 +293,7 @@ def generate_template(template_pop, config):
     template_pop['upscaler_1'] = config['upscaler_1']
     template_pop['spoiler'] = config['spoiler']
     template_pop['spoiler_role'] = config['spoiler_role']
+    template_pop['live_preview'] = config['live_preview']
     return template_pop
 
 
@@ -515,8 +517,8 @@ def populate_global_vars():
     global_var.prompt_ignore_list = [x for x in config['prompt_ignore_list']]
     global_var.display_ignored_words = config['display_ignored_words']
     global_var.negative_prompt_prefix = [x for x in config['negative_prompt_prefix']]
-    if config['preview_update_interval'] is not None:
-        global_var.preview_update_interval = float(config['preview_update_interval'])
+    if config['live_preview_update_interval'] is not None:
+        global_var.preview_update_interval = float(config['live_preview_update_interval'])
 
     # create persistent session since we'll need to do a few API calls
     s = authenticate_user()

--- a/core/settingscog.py
+++ b/core/settingscog.py
@@ -203,6 +203,12 @@ class SettingsCog(commands.Cog):
         description='Remove assigned spoiler role',
         required=False,
     )
+    @option(
+        'live_preview',
+        bool,
+        description='Enable/Disable live previews in this channel',
+        required=False,
+    )
     async def settings_handler(self, ctx,
                                current_settings: Optional[bool] = True,
                                n_prompt: Optional[str] = None,
@@ -225,7 +231,8 @@ class SettingsCog(commands.Cog):
                                refresh: Optional[bool] = False,
                                spoiler: Optional[bool] = None,
                                spoiler_role: Optional[discord.Role] = None,
-                               remove_spoiler_role: Optional[bool] = None
+                               remove_spoiler_role: Optional[bool] = None,
+                               live_preview: Optional[bool] = None
                                ):
         # get the channel id and check if a settings file exists
         channel = '% s' % ctx.channel.id
@@ -426,6 +433,11 @@ class SettingsCog(commands.Cog):
         elif spoiler_role is not None:
             settings.update(channel, 'spoiler_role', str(spoiler_role.id))
             new += f'\n Spoiler Role: <@&{spoiler_role.id}>'
+            set_new = True
+
+        if live_preview is not None:
+            settings.update(channel, 'live_preview', live_preview)
+            new += f'\nLive Preview: ``{live_preview}``'
             set_new = True
 
         if set_new:

--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -1,6 +1,7 @@
 import discord
 import random
 import re
+import requests
 import os
 from discord.ui import InputText, Modal, View
 
@@ -299,7 +300,47 @@ class DrawModal(Modal):
             else:
                 await queuehandler.process_dream(draw_dream, queuehandler.DrawObject(stablecog.StableCog(self), *prompt_tuple, DrawView(prompt_tuple)))
             await interaction.response.send_message(f'<@{interaction.user.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.queue)}``{prompt_output}')
+# view that holds the interrupt button for progress
+class ProgressView(View):
+    def __init__(self):
+        super().__init__(timeout=None)
 
+    @discord.ui.button(
+        custom_id="button_interrupt",
+        emoji="❌")
+    async def button_interrupt(self, button, interaction):
+        try:
+            if str(interaction.user.id) not in interaction.message.content:
+                await interaction.response.send_message("Cannot interrupt other people's tasks!", ephemeral=True)
+                return
+            button.disabled = True
+            s = settings.authenticate_user()
+            s.post(url=f'{settings.global_var.url}/sdapi/v1/interrupt')
+            await interaction.response.edit_message(view=self)
+        except Exception as e:
+            button.disabled = True
+            await interaction.response.send_message("I have no idea why, but I broke. Either the request has fallen "
+                                                    "through "
+                                                    "or I no longer have the message in my cache.\n"
+                                                    f"Good luck:\n`{str(e)}`", ephemeral=True)
+    @discord.ui.button(
+        custom_id="button_skip",
+        emoji="➡️")
+    async def button_skip(self, button, interaction):
+        try:
+            if str(interaction.user.id) not in interaction.message.content:
+                await interaction.response.send_message("Cannot skip other people's tasks!", ephemeral=True)
+                return
+            button.disabled = True
+            s = settings.authenticate_user()
+            s.post(url=f'{settings.global_var.url}/sdapi/v1/skip')
+            await interaction.response.edit_message(view=self)
+        except Exception as e:
+            button.disabled = True
+            await interaction.response.send_message("I have no idea why, but I broke. Either the request has fallen "
+                                                    "through "
+                                                    "or I no longer have the message in my cache.\n"
+                                                    f"Good luck:\n`{str(e)}`", ephemeral=True)
 
 # creating the view that holds the buttons for /draw output
 class DrawView(View):


### PR DESCRIPTION
This PR supersedes #234 -- it is functionally the same but has been rebased on top of 1b17f175cbf10786dfb404c31645928a5d8dd1a5 and has all of the minor/cleanup commits squashed into major changes. Additional changes not in #234:

* Uses job presence for end-of-generation detection
* Handles progress without image previews
* Implements `live_preview` per-channel setting