### PR TITLE
Removed bug of generate command

### DIFF
--- a/core/generatecog.py
+++ b/core/generatecog.py
@@ -22,13 +22,13 @@ class GenerateCog(commands.Cog):
 
     @commands.slash_command(name='generate', description='Generates a prompt from text', guild_only=True)
     @option(
-        'Text',
+        'text',
         str,
         description='Your text to produce the prompt.',
         required=True,
     )
     async def generate_handler(self, ctx: discord.ApplicationContext, *,
-                            prompt: Optional[str]):
+                            text: str):
 
         # set up the queue
         if queuehandler.GlobalQueue.generate_thread.is_alive():

--- a/core/generatecog.py
+++ b/core/generatecog.py
@@ -32,11 +32,11 @@ class GenerateCog(commands.Cog):
 
         # set up the queue
         if queuehandler.GlobalQueue.generate_thread.is_alive():
-            queuehandler.GlobalQueue.generate_queue.append(queuehandler.GenerateObject(self, ctx, prompt))
+            queuehandler.GlobalQueue.generate_queue.append(queuehandler.GenerateObject(self, ctx, text))
         else:
-            await queuehandler.process_generate(self, queuehandler.GenerateObject(self, ctx, prompt))
+            await queuehandler.process_generate(self, queuehandler.GenerateObject(self, ctx, text))
 
-        await ctx.send_response(f"<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.generate_queue)}`` - Your text: ``{prompt}``")
+        await ctx.send_response(f"<@{ctx.author.id}>, {settings.messages()}\nQueue: ``{len(queuehandler.GlobalQueue.generate_queue)}`` - Your text: ``{text}``")
 
     def post(self, event_loop: AbstractEventLoop, post_queue_object: queuehandler.PostObject):
         event_loop.create_task(
@@ -52,7 +52,7 @@ class GenerateCog(commands.Cog):
     def dream(self, event_loop: AbstractEventLoop, queue_object: queuehandler.GenerateObject):
         try:
             # generate the text
-            res = self.pipe(queue_object.prompt)
+            res = self.pipe(queue_object.text)
             generated_text = res[0]['generated_text']
 
             # Create an Embed object

--- a/core/queuehandler.py
+++ b/core/queuehandler.py
@@ -61,10 +61,10 @@ class IdentifyObject:
 
 # the queue object for generate
 class GenerateObject:
-    def __init__(self, cog, ctx, prompt):
+    def __init__(self, cog, ctx, text):
         self.cog = cog
         self.ctx = ctx
-        self.prompt = prompt
+        self.text = text
         
 
 # the queue object for posting to Discord


### PR DESCRIPTION
This PR removes bug of generate command.
For now using `/generate` command we have OPTIONAL `prompt` without description instead of `text` which is required
Because we need to generate a `prompt` from `text`, not a `prompt` from `prompt`

Before:
![1](https://github.com/Kilvoctu/aiyabot/assets/32651506/107e81a4-de77-4422-ad34-287777af379d)
after:
![2](https://github.com/Kilvoctu/aiyabot/assets/32651506/c4d1a8c8-3ab7-4b65-a25e-feddbeba2942)
