### PR TITLE
fix: Sanitize and deduplicate extra_net usage

### DIFF
--- a/core/viewhandler.py
+++ b/core/viewhandler.py
@@ -105,7 +105,9 @@ class DrawModal(Modal):
     async def callback(self, interaction: discord.Interaction):
         # update the tuple with new prompts
         pen = list(self.input_tuple)
-        pen[2] = pen[2].replace(pen[1], self.children[0].value)
+        # dedup ensures that if user added lora/hypernet manually to edited prompt
+        # it is not duplicated from previous "non-simple" prompt on replacement
+        pen[2] = settings.extra_net_dedup(pen[2].replace(pen[1], self.children[0].value))
         pen[1] = self.children[0].value
         pen[3] = self.children[1].value
 
@@ -127,7 +129,7 @@ class DrawModal(Modal):
         # if extra network is used, find the multiplier
         if pen[18]:
             if pen[18] in pen[2]:
-                net_multi = re.search(f'{pen[18]}:(.*)>', pen[2]).group(1)
+                net_multi = re.search(f'<lora:{re.escape(pen[18])}:(.*?)>', pen[2]).group(1)
 
         # iterate through extended edit for any changes
         for line in self.children[3].value.split('\n'):


### PR DESCRIPTION
## net_multi regex fix

The previous regex for finding `net_multi` value from given `extra_net` -- `re.search(f'{pen[18]}:(.*)>', pen[2])`:
* Did not escape user input which could cause errors if lora name had special characters
  * Fixed by escaping with `re.escape` 
* The use of `(.*)` is greedy and could cause a bad capture group if there were subsequent extra_net patterns in the string
  * Fixed by making it lazy `(.*?)`

## extra_net settings

`extra_net_check` and `extra_net_defaults` were both missing if statements to check that the net did not already exist in the prompt before adding. 

## extra_net deduplication

If a user added nets manually to the "new prompt" on the edit flow IE `a cute cat <lora:myLora>` then the callback would add this alongside the calculated extra_nets from the original prompt. A dedup function now removes duplicate occurrences (n > 1) for unique net names in the new prompt IE

`a very cute cat, zavy-ctsmtrc <lora:zavy-ctsmtrc-sdxl:0.7> <lora:zavy-ctsmtrc-sdxl:1> <lora:sdxl_lightning_8step_lora:1>`

becomes

`a very cute cat, zavy-ctsmtrc <lora:zavy-ctsmtrc-sdxl:0.7> <lora:sdxl_lightning_8step_lora:1>`